### PR TITLE
UTF-8 encode when logging data

### DIFF
--- a/lib/httplog/adapters/httpclient.rb
+++ b/lib/httplog/adapters/httpclient.rb
@@ -9,7 +9,7 @@ if defined?(::HTTPClient)
       if log_enabled
         HttpLog.log_request(req.header.request_method, req.header.request_uri)
         HttpLog.log_headers(req.headers)
-        HttpLog.log_data(req.body)# if req.header.request_method == "POST"
+        HttpLog.log_data(req.body)
       end
 
       retryable_response = nil

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -93,6 +93,7 @@ module HttpLog
 
     def log_data(data)
       return if options[:compact_log] || !options[:log_data]
+      data = data.to_s.encode('utf-8', invalid: :replace, undef: :replace) if data
       data = URI.unescape(data) if data
       log("Data: #{data}")
     end


### PR DESCRIPTION
Make sure the request data to be logged is a string and utf-8 encoded
before attempting to URI unescape & display it. Fixes logging of
multi-part http requests which can contain binary files which can mess up
terminals when displayed.

I'm not sure if utf-8 is the right thing to do here, but encoding to ascii would lose a lot of reasonable looking text too.