### PR TITLE
Fix httpclient multi-part data logging

### DIFF
--- a/lib/httplog/adapters/httpclient.rb
+++ b/lib/httplog/adapters/httpclient.rb
@@ -9,7 +9,7 @@ if defined?(::HTTPClient)
       if log_enabled
         HttpLog.log_request(req.header.request_method, req.header.request_uri)
         HttpLog.log_headers(req.headers)
-        HttpLog.log_data(req.body)# if req.header.request_method == "POST"
+        HttpLog.log_data(req.body)
       end
 
       retryable_response = nil

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -93,7 +93,7 @@ module HttpLog
 
     def log_data(data)
       return if options[:compact_log] || !options[:log_data]
-      data = URI.unescape(data) if data
+      data = URI.unescape(data.to_s) if data
       log("Data: #{data}")
     end
 

--- a/spec/adapters/faraday_adapter.rb
+++ b/spec/adapters/faraday_adapter.rb
@@ -15,10 +15,31 @@ class FaradayAdapter < HTTPBaseAdapter
     end
   end
 
+  def send_post_form_request
+    connection.post do |req|
+      req.url parse_uri.to_s
+      req.headers = @headers
+      req.body = @params
+    end
+  end
+
+  def send_multipart_post_request
+    file_upload = Faraday::UploadIO.new(@params['file'], 'text/plain')
+
+    connection.post do |req|
+      req.url parse_uri.to_s
+      req.headers = @headers
+      req.body = @params.merge('file' => file_upload)
+    end
+  end
+
   private
 
   def connection
     Faraday.new(url: "#{@protocol}://#{@host}:#{@port}") do |faraday|
+      faraday.request :multipart
+      faraday.request :url_encoded
+
       faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
     end
   end

--- a/spec/adapters/http_base_adapter.rb
+++ b/spec/adapters/http_base_adapter.rb
@@ -1,19 +1,16 @@
 class HTTPBaseAdapter
-  def initialize(host, port, path, protocol = 'http')
+  def initialize(host, port, path, headers, data, params, protocol = 'http')
     @host = host
     @port = port
     @path = path
+    @headers = headers
+    @data = data
+    @params = params
     @protocol = protocol
-    @headers = { "accept" => "*/*", "foo" => "bar" }
-    @data = "foo=bar%3Azee&bar=foo"
-    @params = {'foo' => 'bar', 'bar' => 'foo'}
   end
 
   def parse_uri
     URI.parse("#{@protocol}://#{@host}:#{@port}#{@path}")
-  end
-
-  def send_post_form_request
   end
 
   def expected_response_body

--- a/spec/adapters/httpclient_adapter.rb
+++ b/spec/adapters/httpclient_adapter.rb
@@ -7,8 +7,12 @@ class HTTPClientAdapter < HTTPBaseAdapter
     ::HTTPClient.post(parse_uri, body: @data, header: @headers)
   end
 
-  def send_post_form_request(params)
-    ::HTTPClient.post_content(parse_uri, params, @headers)
+  def send_post_form_request
+    ::HTTPClient.post(parse_uri, body: @params, header: @headers)
+  end
+
+  def send_multipart_post_request
+    send_post_form_request
   end
 
   def self.response_should_be

--- a/spec/adapters/patron_adapter.rb
+++ b/spec/adapters/patron_adapter.rb
@@ -10,6 +10,19 @@ class PatronAdapter < HTTPBaseAdapter
     session.post(parse_uri.to_s, @data, @headers)
   end
 
+  def send_post_form_request
+    session = Patron::Session.new
+    session.post(parse_uri.to_s, @params, @headers)
+  end
+
+  def send_multipart_post_request
+    data = @params.dup
+    file = @params.delete('file')
+
+    session = Patron::Session.new
+    session.post_multipart(parse_uri.to_s, data, {file: file.path}, @headers)
+  end
+
   def self.is_libcurl?
     true
   end

--- a/spec/adapters/typhoeus_adapter.rb
+++ b/spec/adapters/typhoeus_adapter.rb
@@ -9,6 +9,14 @@ class TyphoeusAdapter < HTTPBaseAdapter
     Typhoeus.post(parse_uri.to_s, body: @data, headers: @headers)
   end
 
+  def send_post_form_request
+    Typhoeus.post(parse_uri.to_s, body: @params, headers: @headers)
+  end
+
+  def send_multipart_post_request
+    send_post_form_request
+  end
+
   def self.is_libcurl?
     true
   end


### PR DESCRIPTION
URI.unescape chokes on non-string data, so always string-ify first. For httpclient file uploads you'd now end up with

```
D, [2015-11-17T11:40:13.994893 #47072] DEBUG -- : [httplog] Data: #<HTTP::Message::Body::Parts:0x007fd23e208358>
```

The result isn't super satisfying, but actually loging the potentially binary files doesn't really look good (and dumps a ton of data). There also doesn't appear to be a nice way to grab just the metadata from a HTTP::Message::Body::Parts which might be nicer when logged

Other tweaks:
- add tests for form data POST
- add tests for uploads/multi-part data POST
- adds form data & multi-part to as many adapters as possible
- adds tags to adapter context, ex: `rspec --tag adapter:HTTPClientAdapter`
- pull adapter variables in to rspec let's for overridability