### PR TITLE
Include httplog library in coverage reports

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,11 @@ require 'typhoeus'
 require 'ethon'
 require 'patron'
 require 'http'
-require 'httplog'
 require 'simplecov'
 
 SimpleCov.start
+
+require 'httplog'
 
 require 'adapters/http_base_adapter'
 Dir[File.dirname(__FILE__) + '/adapters/*.rb'].each { |f| require f }


### PR DESCRIPTION
For my local coverage report it had to be required after SimpleCov to show up