### PR TITLE
Fix UTF-8 encoding issue by using CGI.unescape

### DIFF
--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -93,7 +93,7 @@ module HttpLog
 
     def log_data(data)
       return if options[:compact_log] || !options[:log_data]
-      data = URI.unescape(data.to_s) if data
+      data = CGI.unescape(data.to_s) if data
       log("Data: #{data}")
     end
 

--- a/spec/http_log_spec.rb
+++ b/spec/http_log_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'spec_helper'
 
 describe HttpLog do
@@ -60,6 +62,17 @@ describe HttpLog do
             expect(log).to include(HttpLog::LOG_PREFIX + "Response:#{adapter.expected_response_body}")
 
             expect(res).to be_a adapter.response if adapter.respond_to? :response
+          end
+
+          context "with binary data" do
+            let(:data) { "a UTF-8 striñg with a URI encoded invalid codepoint %c3" }
+            let(:unescaped_data) { "a UTF-8 striñg with a URI encoded invalid codepoint \xC3" }
+
+            it "should log POST data converted to UTF-8" do
+              adapter.send_post_request
+
+              expect(log.force_encoding(Encoding::ASCII_8BIT)).to include(unescaped_data.force_encoding(Encoding::ASCII_8BIT))
+            end
           end
         end
       end


### PR DESCRIPTION
Adds failing test where UTF-8 data containing invalid UTF sequences that
are (or happen to be) url encoded caused exceptions. URI.unescape seems
to be deprecated[1], even though the docs don't say anything about it.
Using CGI.unescape avoids the exception.

Binary (including invalid UTF-8) will still be logged to the terminal, but this seems to be fine for me locally, it just replaces them with question marks. If we wanted to always output valid UTF-8/whatever-default-encoding-is we could force encode it with
```
data = CGI.escape(data.to_s.encode(invalid: :replace, undef: :replace))
```
which would force replace things with the appropriate unknown-symbol for the default encoding

1: https://github.com/ruby/ruby/commit/238b979f1789f95262a267d8df6239806f2859cc