### PR TITLE
Customizable prefixes

### DIFF
--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -18,7 +18,9 @@ module HttpLog
     :compact_log           => false,
     :url_whitelist_pattern => /.*/,
     :url_blacklist_pattern => nil,
-    :color                 => false
+    :color                 => false,
+    :prefix_response_lines => false,
+    :prefix_line_numbers   => false
   }
 
   LOG_PREFIX = "[httplog] ".freeze
@@ -99,7 +101,19 @@ module HttpLog
 
       data = utf_encoded(body.to_s, content_type)
 
-      log("Response:\n#{data}")
+      if options[:prefix_response_lines]
+        log("Response:")
+        data.each_line.with_index do |line, row|
+          if options[:prefix_line_numbers]
+            log("#{row + 1}: #{line.strip}")
+          else
+            log(line.strip)
+          end
+        end
+      else
+        log("Response:\n#{data}")
+      end
+
     end
 
     def log_data(data)
@@ -134,5 +148,6 @@ module HttpLog
       content_type =~ /^text/ || 
       content_type =~ /^application/ && content_type != 'application/octet-stream'
     end
+
   end
 end

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -22,6 +22,7 @@ module HttpLog
     :url_whitelist_pattern => /.*/,
     :url_blacklist_pattern => nil,
     :color                 => false,
+    :prefix_data_lines     => false,
     :prefix_response_lines => false,
     :prefix_line_numbers   => false
   }
@@ -105,13 +106,7 @@ module HttpLog
 
       if options[:prefix_response_lines]
         log("Response:")
-        data.each_line.with_index do |line, row|
-          if options[:prefix_line_numbers]
-            log("#{row + 1}: #{line.strip}")
-          else
-            log(line.strip)
-          end
-        end
+        log_data_lines(data)
       else
         log("Response:\n#{data}")
       end
@@ -121,7 +116,13 @@ module HttpLog
     def log_data(data)
       return if options[:compact_log] || !options[:log_data]
       data = utf_encoded(data.to_s)
-      log("Data: #{data}")
+
+      if options[:prefix_data_lines]
+        log("Data:")
+        log_data_lines(data)
+      else
+        log("Data: #{data}")
+      end
     end
 
     def log_compact(method, uri, status, seconds)
@@ -149,6 +150,16 @@ module HttpLog
       # heavy-handed checks.
       content_type =~ /^text/ || 
       content_type =~ /^application/ && content_type != 'application/octet-stream'
+    end
+
+    def log_data_lines(data)
+      data.each_line.with_index do |line, row|
+        if options[:prefix_line_numbers]
+          log("#{row + 1}: #{line.chomp}")
+        else
+          log(line.strip)
+        end
+      end
     end
 
     def prefix

--- a/spec/http_log_spec.rb
+++ b/spec/http_log_spec.rb
@@ -192,6 +192,20 @@ describe HttpLog do
             adapter.send_get_request
             expect(log.colorized?).to be_truthy
           end
+
+          it "should log with custom string prefix" do
+            HttpLog.options[:prefix] = '[my logger]'
+            adapter.send_get_request
+            expect(log).to include("[my logger]")
+            expect(log).to_not include(HttpLog::LOG_PREFIX)
+          end
+
+          it "should log with custom lambda prefix" do
+            HttpLog.options[:prefix] = -> { '[custom prefix]' }
+            adapter.send_get_request
+            expect(log).to include("[custom prefix]")
+            expect(log).to_not include(HttpLog::LOG_PREFIX)
+          end
         end
 
         context "POST requests" do

--- a/spec/http_log_spec.rb
+++ b/spec/http_log_spec.rb
@@ -208,6 +208,23 @@ describe HttpLog do
               expect(log).to_not include(HttpLog::LOG_PREFIX + "Reponse:")
             end
 
+            it "should prefix all response lines" do
+              HttpLog.options[:prefix_response_lines] = true
+
+              adapter.send_post_request
+              expect(log).to include(HttpLog::LOG_PREFIX + "Response:")
+              expect(log).to include(HttpLog::LOG_PREFIX + "<html>")
+            end
+
+            it "should prefix all response lines with line numbers" do
+              HttpLog.options[:prefix_response_lines] = true
+              HttpLog.options[:prefix_line_numbers] = true
+
+              adapter.send_post_request
+              expect(log).to include(HttpLog::LOG_PREFIX + "Response:")
+              expect(log).to include(HttpLog::LOG_PREFIX + "1: <html>")
+            end
+
             it "should not log the benchmark if disabled" do
               HttpLog.options[:log_benchmark] = false
               adapter.send_post_request


### PR DESCRIPTION
This PR includes the following changes regarding prefixing:

* The custom option `prefix` enables clients to control how the prefix of each log line will look like. A String or  proc/lambda can be provided as an option
* The options `prefix_data_lines` and `prefix_response_lines` change the way request and response bodies are printed. When set with true each line is prefixed in order to facilitate log filtering in environments with heavy logging from multiple sources. 
The `prefix_line_numbers` option controls if a line counter should be included in prefix as well. This behavior is applied in both payloads (response body and request data)