### PR TITLE
don't decompress empty body

### DIFF
--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -76,7 +76,7 @@ module HttpLog
         return
       end
 
-      if encoding =~ /gzip/
+      if encoding =~ /gzip/ && body && !body.empty?
         sio = StringIO.new( body.to_s )
         gz = Zlib::GzipReader.new( sio )
         body = gz.read

--- a/spec/adapters/ethon_adapter.rb
+++ b/spec/adapters/ethon_adapter.rb
@@ -6,6 +6,12 @@ class EthonAdapter < HTTPBaseAdapter
     easy.perform
   end
 
+  def send_head_request
+    easy = Ethon::Easy.new
+    easy.http_request(parse_uri.to_s, :head, { headers: @headers })
+    easy.perform
+  end
+
   def send_post_request
     easy = Ethon::Easy.new
     easy.http_request(parse_uri.to_s, :post, { headers: @headers, body: @data })

--- a/spec/adapters/excon_adapter.rb
+++ b/spec/adapters/excon_adapter.rb
@@ -4,6 +4,10 @@ class ExconAdapter < HTTPBaseAdapter
     Excon.get(parse_uri.to_s, headers: @headers )
   end
 
+  def send_head_request
+    Excon.head(parse_uri.to_s, headers: @headers)
+  end
+
   def send_post_request
     Excon.post(parse_uri.to_s, body: @data, headers: @headers)
   end

--- a/spec/adapters/faraday_adapter.rb
+++ b/spec/adapters/faraday_adapter.rb
@@ -7,6 +7,13 @@ class FaradayAdapter < HTTPBaseAdapter
     end
   end
 
+  def send_head_request
+    connection.head do |req|
+      req.url parse_uri.to_s
+      req.headers = @headers
+    end
+  end
+
   def send_post_request
     connection.post do |req|
       req.url parse_uri.to_s

--- a/spec/adapters/http_adapter.rb
+++ b/spec/adapters/http_adapter.rb
@@ -4,6 +4,10 @@ class HTTPAdapter < HTTPBaseAdapter
     client.get(parse_uri.to_s)
   end
 
+  def send_head_request
+    client.head(parse_uri.to_s)
+  end
+
   def send_post_request
     client.post(parse_uri.to_s, body: @data)
   end

--- a/spec/adapters/httparty_adapter.rb
+++ b/spec/adapters/httparty_adapter.rb
@@ -4,6 +4,10 @@ class HTTPartyAdapter < HTTPBaseAdapter
     HTTParty.get(parse_uri.to_s, headers: @headers)
   end
 
+  def send_head_request
+    HTTParty.head(parse_uri.to_s, headers: @headers)
+  end
+
   def send_post_request
     HTTParty.post(parse_uri.to_s, body: @data, headers: @headers)
   end

--- a/spec/adapters/httpclient_adapter.rb
+++ b/spec/adapters/httpclient_adapter.rb
@@ -3,6 +3,10 @@ class HTTPClientAdapter < HTTPBaseAdapter
     ::HTTPClient.get(parse_uri, header: @headers)
   end
 
+  def send_head_request
+    ::HTTPClient.head(parse_uri, header: @headers)
+  end
+
   def send_post_request
     ::HTTPClient.post(parse_uri, body: @data, header: @headers)
   end

--- a/spec/adapters/net_http_adapter.rb
+++ b/spec/adapters/net_http_adapter.rb
@@ -3,6 +3,11 @@ class NetHTTPAdapter < HTTPBaseAdapter
     Net::HTTP.get_response(@host, [@path, @data].compact.join('?'), @port)
   end
 
+  def send_head_request
+    http = Net::HTTP.new(@host, @port)
+    http.head(@path, @headers)
+  end
+
   def send_post_request
     http = Net::HTTP.new(@host, @port)
     resp = http.post(@path, @data)

--- a/spec/adapters/patron_adapter.rb
+++ b/spec/adapters/patron_adapter.rb
@@ -5,6 +5,11 @@ class PatronAdapter < HTTPBaseAdapter
     session.get(parse_uri.to_s, @headers)
   end
 
+  def send_head_request
+    session = Patron::Session.new
+    session.head(parse_uri.to_s, @headers)
+  end
+
   def send_post_request
     session = Patron::Session.new
     session.post(parse_uri.to_s, @data, @headers)

--- a/spec/adapters/typhoeus_adapter.rb
+++ b/spec/adapters/typhoeus_adapter.rb
@@ -5,6 +5,10 @@ class TyphoeusAdapter < HTTPBaseAdapter
     Typhoeus.get(parse_uri.to_s, headers: @headers)
   end
 
+  def send_head_request
+    Typhoeus.head(parse_uri.to_s, headers: @headers)
+  end
+
   def send_post_request
     Typhoeus.post(parse_uri.to_s, body: @data, headers: @headers)
   end

--- a/spec/http_log_spec.rb
+++ b/spec/http_log_spec.rb
@@ -60,6 +60,13 @@ describe HttpLog do
               adapter.send_get_request
               expect(log).to include(HttpLog::LOG_PREFIX + "Response:#{adapter.expected_response_body}")
             end
+
+            if adapter_class.method_defined? :send_head_request
+              it "doesn't try to decompress body for HEAD requests" do
+                adapter.send_head_request
+                expect(log).to include(HttpLog::LOG_PREFIX + "Response:")
+              end
+            end
           end
 
           context "with UTF-8 response body" do


### PR DESCRIPTION
Some servers return `Content-Encoding` gzip with an empty body. This can occur with HEAD responses, or GET responses with 301/302 redirects. Trying to read an empty gzip body results in an error `Zlib::GzipFile::Error: not in gzip format`. HttpLog shouldn't try to unzip empty or nil response bodies.