### PR TITLE
Fix error when submitting POST with frozen body

### DIFF
--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -95,7 +95,7 @@ module HttpLog
 
     def log_data(data)
       return if config.compact_log || !config.log_data
-      data = utf_encoded(data.to_s)
+      data = utf_encoded(data.to_s.dup)
 
       if config.prefix_data_lines
         log("Data:")

--- a/spec/http_log_spec.rb
+++ b/spec/http_log_spec.rb
@@ -111,7 +111,7 @@ describe HttpLog do
           end
 
           context "with non-UTF request data" do
-            let(:data) { "a UTF-8 striñg with an 8BIT-ASCII character: \xC3" }
+            let(:data) { "a UTF-8 striñg with an 8BIT-ASCII character: \xC3".freeze }
             it "does not raise and error" do
               expect {adapter.send_post_request }.to_not raise_error
               expect(log).to include(HttpLog::LOG_PREFIX + "Response:")


### PR DESCRIPTION
If you will try to send a POST with frozen string as a payload (it's easy to accomplish with `# frozen_string_literal: true` pragma in sources) you will get an exception that you are trying to change frozen string (by calling `force_encoding` in `utf_encoded` method).

One thing that worries me is that httplog changes POST data in place, that might lead to errors that ar impossible reproduce (because there is usually no httplog installed in production).