### PR TITLE
Add Return response for http log on Patron

### DIFF
--- a/lib/httplog/adapters/patron.rb
+++ b/lib/httplog/adapters/patron.rb
@@ -22,6 +22,8 @@ if defined?(Patron)
           HttpLog.log_benchmark(bm)
           HttpLog.log_body(@response.body, headers['Content-Encoding'], headers['Content-Type'])
         end
+
+        @response
       end
     end
   end


### PR DESCRIPTION
### Why 
Using httplog with patron leads on lost of response. 

### What

Add @response to be returned after logging is done.