### PR TITLE
Require 'rack' explicitly

### DIFF
--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -2,6 +2,7 @@ require "net/http"
 require "logger"
 require "benchmark"
 require "colorize"
+require "rack"
 
 module HttpLog
   LOG_PREFIX = "[httplog] ".freeze


### PR DESCRIPTION
This gem works great for plain ruby program but it utilizes some Rack functionalities. Instead of assuming 'rack' is already imported (or ask users to import 'rack' manually), require it here explicitly.

See #45.