### PR TITLE
Fix request data logging for httprb/http version 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg/
 *.gem
 coverage/
 spec/log/*.log
+gemfiles/*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ rvm:
   - "2.2.8"
   - "2.3.5"
   - "2.4.2"
+gemfile:
+  - gemfiles/http2.gemfile
+  - gemfiles/http3.gemfile
+  - gemfiles/http4.gemfile
 # uncomment this line if your project needs to run something other than `rake`:
 script: bundle exec rspec spec
 # workaround for https://github.com/travis-ci/travis-ci/issues/5239:

--- a/gemfiles/http2.gemfile
+++ b/gemfiles/http2.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "http", "~> 2.0"
+
+gemspec path: ".."

--- a/gemfiles/http3.gemfile
+++ b/gemfiles/http3.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "http", "~> 3.0"
+
+gemspec path: ".."

--- a/gemfiles/http4.gemfile
+++ b/gemfiles/http4.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "http", github: "httprb/http"
+
+gemspec path: ".."

--- a/lib/httplog/adapters/http.rb
+++ b/lib/httplog/adapters/http.rb
@@ -14,8 +14,13 @@ if defined?(::HTTP::Client) && defined?(::HTTP::Connection)
         if log_enabled
           HttpLog.log_request(req.verb, req.uri)
           HttpLog.log_headers(req.headers.to_h)
-          body = req.body
-          body = body.source if body.respond_to?(:source)
+
+          if defined?(::HTTP::Request::Body)
+            body = req.body.respond_to?(:source) ? req.body.source : req.body.instance_variable_get(:@body)
+          else
+            body = req.body
+          end
+
           HttpLog.log_data(body.to_s)
           body.rewind if body.respond_to?(:rewind)
         end

--- a/lib/httplog/adapters/http.rb
+++ b/lib/httplog/adapters/http.rb
@@ -14,7 +14,10 @@ if defined?(::HTTP::Client) && defined?(::HTTP::Connection)
         if log_enabled
           HttpLog.log_request(req.verb, req.uri)
           HttpLog.log_headers(req.headers.to_h)
-          HttpLog.log_data(req.body) #if req.verb == :post
+          body = req.body
+          body = body.source if body.respond_to?(:source)
+          HttpLog.log_data(body.to_s)
+          body.rewind if body.respond_to?(:rewind)
         end
 
         bm = Benchmark.realtime do


### PR DESCRIPTION
Since version 3, httprb/http gem logs request data like this:
`[httplog] Data: #<HTTP::Request::Body:0x00007ffa7e32ccd0>`

Unfortunately, it's difficult to make version 3 work, but in version 4 (currently in development and only available in master) they added `HTTP::Request::Body#source`, so we can do stuff like `source.to_s` and `source.rewind`. This patch fixes cases for plaintext body and form body types. Note that we are just using `to_s` on source so that file bodies are going to be logged like `#<File:0x00007ffabb2ba620>` which I think is OK because we don't want to read the whole file.

Travis is not configured to test different gem versions for this repo, but I tested the patch locally and all specs pass if you add `gem "http", github: "httprb/http"` to the Gemfile (one spec fails if you update http gem to version 3).
