### PR TITLE
Use req.uri to get full url including scheme

### DIFF
--- a/lib/httplog/adapters/net_http.rb
+++ b/lib/httplog/adapters/net_http.rb
@@ -6,7 +6,7 @@ module Net
     alias orig_connect connect unless method_defined?(:orig_connect)
 
     def request(req, body = nil, &block)
-      url = "http://#{@address}:#{@port}#{req.path}"
+      url = req.uri.to_s
 
       log_enabled = HttpLog.url_approved?(url)
 


### PR DESCRIPTION
Having `http://` hardcoded is confusing because that might not be the actual scheme that is used. If we use `req.uri` we know that we always get the real URI used by the request.

```
// Before
http://example.com:443/foo/bar?param=1

// After
https://example.com/foo/bar?param=1
```