### PR TITLE
Enable JSON logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ gemfile:
   - gemfiles/rack1.gemfile
   - gemfiles/rack2.gemfile
 
+matrix:
+  allow_failures:
+    - rvm: "2.2.8"
+    - gemfile: "gemfiles/http4.gemfile"
+
 # uncomment this line if your project needs to run something other than `rake`:
 script: bundle exec rspec spec
 # workaround for https://github.com/travis-ci/travis-ci/issues/5239:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: "2.2.8"
-    - gemfile: "gemfiles/http4.gemfile"
+      gemfile: "gemfiles/http4.gemfile"
 
 # uncomment this line if your project needs to run something other than `rake`:
 script: bundle exec rspec spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    httplog (1.1.1)
+    httplog (1.1.2)
       rack (>= 1.0)
       rainbow (>= 2.0.0)
 
@@ -123,4 +123,4 @@ DEPENDENCIES
   thin (~> 1.7)
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ For more color options please refer to the [rainbow documentation](https://githu
 
 If the log is too noisy for you, but you don't want to completely disable it either, set the `compact_log` option to `true`. This will log each request in a single line with method, request URI, response status and time, but no data or headers. No need to disable any other options individually.
 
+### JSON logging
+
+If you want to log HTTP requests in a compact JSON format, set the `json_log` option to `true` and the `compact_log` option (which takes precedence) to `false`.
+
 ### Example
 
 With the default configuration, the log output might look like this:
@@ -135,6 +139,10 @@ With the default configuration, the log output might look like this:
 With `compact_log` enabled, the same request might look like this:
 
     [httplog] GET http://localhost:9292/index.html completed with status code 200 in 0.00057 seconds
+
+With `json_log` enabled, the same request might look like this:
+
+    [httplog] {"method":"GET","url":"localhost:80","request_body":null, "request_headers":{"foo":"bar"}, "response_code":200,"response_body":"<html>\n      <head>\n        <title>Test Page</title>\n      </head>\n      <body>\n        <h1>This is the test page.</h1>\n      </body>\n    </html>","response_headers":{"foo":"bar"},"benchmark":0.00057}
 
 ### Known Issues
 

--- a/lib/httplog/adapters/ethon.rb
+++ b/lib/httplog/adapters/ethon.rb
@@ -46,7 +46,9 @@ if defined?(Ethon)
             response_code: @return_code,
             response_body: response_body,
             response_headers: headers.map{ |header| header.split(/:\s/) }.to_h,
-            benchmark: bm
+            benchmark: bm,
+            encoding: encoding,
+            content_type: content_type
           )
           HttpLog.log_status(status)
           HttpLog.log_benchmark(bm)

--- a/lib/httplog/adapters/ethon.rb
+++ b/lib/httplog/adapters/ethon.rb
@@ -9,6 +9,7 @@ if defined?(Ethon)
         alias orig_http_request http_request
         def http_request(url, action_name, options = {})
           @action_name = action_name # remember this for compact logging
+          @options = options         # remember this for compact logging
           if HttpLog.url_approved?(url)
             HttpLog.log_request(action_name, url)
             HttpLog.log_headers(options[:headers])
@@ -37,6 +38,16 @@ if defined?(Ethon)
           headers = response_headers.split(/\r?\n/)[1..-1]
 
           HttpLog.log_compact(@action_name, @url, @return_code, bm)
+          HttpLog.log_json(
+            method: @action_name,
+            url: @url,
+            request_body: @options[:body],
+            request_headers: @options[:headers],
+            response_code: @return_code,
+            response_body: response_body,
+            response_headers: headers.map{ |header| header.split(/:\s/) }.to_h,
+            benchmark: bm
+          )
           HttpLog.log_status(status)
           HttpLog.log_benchmark(bm)
           HttpLog.log_headers(headers)

--- a/lib/httplog/adapters/excon.rb
+++ b/lib/httplog/adapters/excon.rb
@@ -58,6 +58,8 @@ if defined?(Excon)
         response = datum[:response]
         headers = response[:headers] || {}
         url = _httplog_url(datum)
+        encoding = headers['Content-Encoding']
+        content_type = headers['Content-Type']
 
         HttpLog.log_json(
           method: datum[:method],
@@ -67,11 +69,14 @@ if defined?(Excon)
           response_code: response[:status],
           response_body: response[:body],
           response_headers: response[:headers],
-          benchmark: bm)
+          benchmark: bm,
+          encoding: encoding,
+          content_type: content_type
+        )
 
         HttpLog.log_status(response[:status])
         HttpLog.log_headers(headers)
-        HttpLog.log_body(response[:body], headers['Content-Encoding'], headers['Content-Type'])
+        HttpLog.log_body(response[:body], encoding, content_type)
         datum
       end
     end

--- a/lib/httplog/adapters/http.rb
+++ b/lib/httplog/adapters/http.rb
@@ -30,6 +30,9 @@ if defined?(::HTTP::Client) && defined?(::HTTP::Connection)
 
         if log_enabled
           headers = @response.headers
+          encoding = headers['Content-Encoding']
+          content_type = headers['Content-Type']
+
           HttpLog.log_compact(req.verb, req.uri, @response.code, bm)
           HttpLog.log_json(
             method: req.verb,
@@ -39,12 +42,14 @@ if defined?(::HTTP::Client) && defined?(::HTTP::Connection)
             response_code: @response.code,
             response_body: @response.body,
             response_headers: @response.headers,
-            benchmark: bm
+            benchmark: bm,
+            encoding: encoding,
+            content_type: content_type
           )
           HttpLog.log_status(@response.code)
           HttpLog.log_benchmark(bm)
           HttpLog.log_headers(@response.headers.to_h)
-          HttpLog.log_body(@response.body, headers['Content-Encoding'], headers['Content-Type'])
+          HttpLog.log_body(@response.body, encoding, content_type)
         end
 
         @response

--- a/lib/httplog/adapters/http.rb
+++ b/lib/httplog/adapters/http.rb
@@ -31,6 +31,16 @@ if defined?(::HTTP::Client) && defined?(::HTTP::Connection)
         if log_enabled
           headers = @response.headers
           HttpLog.log_compact(req.verb, req.uri, @response.code, bm)
+          HttpLog.log_json(
+            method: req.verb,
+            url: req.uri,
+            request_body: body,
+            request_headers: req.headers,
+            response_code: @response.code,
+            response_body: @response.body,
+            response_headers: @response.headers,
+            benchmark: bm
+          )
           HttpLog.log_status(@response.code)
           HttpLog.log_benchmark(bm)
           HttpLog.log_headers(@response.headers.to_h)

--- a/lib/httplog/adapters/httpclient.rb
+++ b/lib/httplog/adapters/httpclient.rb
@@ -28,6 +28,16 @@ if defined?(::HTTPClient)
         res = conn.pop
         headers = res.headers
         HttpLog.log_compact(req.header.request_method, req.header.request_uri, res.status_code, bm)
+        HttpLog.log_json(
+          method: req.header.request_method,
+          url: req.header.request_uri,
+          request_body: req.body,
+          request_headers: req.headers,
+          response_code: res.status_code,
+          response_body: res.body,
+          response_headers: headers,
+          benchmark: bm
+        )
         HttpLog.log_status(res.status_code)
         HttpLog.log_benchmark(bm)
         HttpLog.log_headers(headers)

--- a/lib/httplog/adapters/httpclient.rb
+++ b/lib/httplog/adapters/httpclient.rb
@@ -27,6 +27,9 @@ if defined?(::HTTPClient)
       if log_enabled
         res = conn.pop
         headers = res.headers
+        encoding = headers['Content-Encoding']
+        content_type = headers['Content-Type']
+
         HttpLog.log_compact(req.header.request_method, req.header.request_uri, res.status_code, bm)
         HttpLog.log_json(
           method: req.header.request_method,
@@ -36,12 +39,14 @@ if defined?(::HTTPClient)
           response_code: res.status_code,
           response_body: res.body,
           response_headers: headers,
-          benchmark: bm
+          benchmark: bm,
+          encoding: encoding,
+          content_type: content_type
         )
         HttpLog.log_status(res.status_code)
         HttpLog.log_benchmark(bm)
         HttpLog.log_headers(headers)
-        HttpLog.log_body(res.body, headers['Content-Encoding'], headers['Content-Type'])
+        HttpLog.log_body(res.body, encoding, content_type)
         conn.push(res)
       end
 

--- a/lib/httplog/adapters/net_http.rb
+++ b/lib/httplog/adapters/net_http.rb
@@ -23,7 +23,16 @@ module Net
       end
 
       if log_enabled && started?
-        HttpLog.log_compact(req.method, url, @response.code, bm)
+        HttpLog.log_json(
+          method: req.method,
+          url: url,
+          request_body: req.body.nil? || req.body.empty? ? body : req.body,
+          request_headers: req.each_header.collect,
+          response_code: @response.code,
+          response_body: @response.body,
+          response_headers: @response.each_header.collect,
+          benchmark: bm
+        )
         HttpLog.log_status(@response.code)
         HttpLog.log_benchmark(bm)
         HttpLog.log_headers(@response.each_header.collect)

--- a/lib/httplog/adapters/net_http.rb
+++ b/lib/httplog/adapters/net_http.rb
@@ -24,6 +24,10 @@ module Net
 
       if log_enabled && started?
         HttpLog.log_compact(req.method, url, @response.code, bm)
+
+        encoding = @response['Content-Encoding']
+        content_type = @response['Content-Type']
+
         HttpLog.log_json(
           method: req.method,
           url: url,
@@ -32,12 +36,14 @@ module Net
           response_code: @response.code,
           response_body: @response.body,
           response_headers: @response.each_header.collect,
-          benchmark: bm
+          benchmark: bm,
+          encoding: encoding,
+          content_type: content_type
         )
         HttpLog.log_status(@response.code)
         HttpLog.log_benchmark(bm)
         HttpLog.log_headers(@response.each_header.collect)
-        HttpLog.log_body(@response.body, @response['Content-Encoding'], @response['Content-Type'])
+        HttpLog.log_body(@response.body, encoding, content_type)
       end
 
       @response

--- a/lib/httplog/adapters/net_http.rb
+++ b/lib/httplog/adapters/net_http.rb
@@ -23,6 +23,7 @@ module Net
       end
 
       if log_enabled && started?
+        HttpLog.log_compact(req.method, url, @response.code, bm)
         HttpLog.log_json(
           method: req.method,
           url: url,

--- a/lib/httplog/adapters/patron.rb
+++ b/lib/httplog/adapters/patron.rb
@@ -20,6 +20,16 @@ if defined?(Patron)
         if log_enabled
           headers = @response.headers
           HttpLog.log_compact(action_name, url, @response.status, bm)
+          HttpLog.log_json(
+            method: action_name,
+            url: url,
+            request_body: options[:data],
+            request_headers: headers,
+            response_code: @response.status,
+            response_body: @response.body,
+            response_headers: headers,
+            benchmark: bm
+          )
           HttpLog.log_status(@response.status)
           HttpLog.log_benchmark(bm)
           HttpLog.log_headers(headers)

--- a/lib/httplog/adapters/patron.rb
+++ b/lib/httplog/adapters/patron.rb
@@ -19,6 +19,9 @@ if defined?(Patron)
 
         if log_enabled
           headers = @response.headers
+          encoding = headers['Content-Encoding']
+          content_type =headers['Content-Type']
+
           HttpLog.log_compact(action_name, url, @response.status, bm)
           HttpLog.log_json(
             method: action_name,
@@ -28,12 +31,14 @@ if defined?(Patron)
             response_code: @response.status,
             response_body: @response.body,
             response_headers: headers,
-            benchmark: bm
+            benchmark: bm,
+            encoding: encoding,
+            content_type: content_type
           )
           HttpLog.log_status(@response.status)
           HttpLog.log_benchmark(bm)
           HttpLog.log_headers(headers)
-          HttpLog.log_body(@response.body, headers['Content-Encoding'], headers['Content-Type'])
+          HttpLog.log_body(@response.body, encoding, content_type)
         end
 
         @response

--- a/lib/httplog/configuration.rb
+++ b/lib/httplog/configuration.rb
@@ -4,6 +4,7 @@ module HttpLog
   class Configuration
     attr_accessor :enabled,
                   :compact_log,
+                  :json_log,
                   :logger,
                   :severity,
                   :prefix,
@@ -24,6 +25,7 @@ module HttpLog
     def initialize
       @enabled               = true
       @compact_log           = false
+      @json_log              = false
       @logger                = Logger.new($stdout)
       @severity              = Logger::Severity::DEBUG
       @prefix                = LOG_PREFIX

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -119,6 +119,9 @@ module HttpLog
 
     def log_json(method:, url:, request_body:, request_headers:, response_code:, response_body:, response_headers:, benchmark:)
       return unless config.json_log
+
+      response_code = transform_response_code(response_code) if response_code.is_a?(Symbol)
+
       log({
         method: method.upcase,
         url: url,
@@ -129,6 +132,10 @@ module HttpLog
         response_headers: response_headers.to_h,
         benchmark: benchmark
       }.to_json)
+    end
+
+    def transform_response_code(response_code_name)
+      Rack::Utils::HTTP_STATUS_CODES.detect{ |k, v| v.to_s.downcase == response_code_name.to_s.downcase }.first
     end
 
     def colorize(msg)

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -64,8 +64,6 @@ module HttpLog
       log("Benchmark: #{seconds.to_f.round(6)} seconds")
     end
 
-    require 'pry'
-
     def log_body(body, encoding = nil, content_type = nil)
       return if already_logged? || !config.log_response
 

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -119,8 +119,7 @@ module HttpLog
 
     def log_json(method:, url:, request_body:, request_headers:, response_code:, response_body:, response_headers:, benchmark:)
       return unless config.json_log
-
-      log({
+      request_details = {
         method: method,
         url: url,
         request_body: request_body,
@@ -129,7 +128,10 @@ module HttpLog
         response_body: response_body,
         response_headers: response_headers,
         benchmark: benchmark
-      }.to_json)
+      }
+      request_details.each { |k, v| request_details[k] = v.force_encoding(Encoding::UTF_8) if v.is_a?(String) }
+      
+      log(request_details)
     end
 
     def colorize(msg)

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -119,7 +119,8 @@ module HttpLog
 
     def log_json(method:, url:, request_body:, request_headers:, response_code:, response_body:, response_headers:, benchmark:)
       return unless config.json_log
-      request_details = {
+
+      log({
         method: method,
         url: url,
         request_body: request_body,
@@ -128,10 +129,7 @@ module HttpLog
         response_body: response_body,
         response_headers: response_headers,
         benchmark: benchmark
-      }
-      request_details.each { |k, v| request_details[k] = v.force_encoding(Encoding::UTF_8) if v.is_a?(String) }
-      
-      log(request_details)
+      }.to_json)
     end
 
     def colorize(msg)

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -119,13 +119,12 @@ module HttpLog
 
     def log_json(method:, url:, request_body:, request_headers:, response_code:, response_body:, response_headers:, benchmark:)
       return unless config.json_log
-
       log({
-        method: method,
+        method: method.upcase,
         url: url,
         request_body: request_body,
         request_headers: request_headers.to_h,
-        response_code: response_code,
+        response_code: response_code.to_i,
         response_body: response_body,
         response_headers: response_headers.to_h,
         benchmark: benchmark

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -180,7 +180,7 @@ module HttpLog
       # it will allow application/json and the like without having to resort to more
       # heavy-handed checks.
       content_type =~ /^text/ ||
-        content_type =~ /^application/ && content_type != 'application/octet-stream'
+        content_type =~ /^application/ && !['application/octet-stream', 'application/pdf'].include?(content_type)
     end
 
     def log_data_lines(data)

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -112,7 +112,7 @@ module HttpLog
     end
 
     def log_compact(method, uri, status, seconds)
-      return unless already_logged?
+      return unless config.compact_log
       status = Rack::Utils.status_code(status) unless status == /\d{3}/
       log("#{method.to_s.upcase} #{uri} completed with status code #{status} in #{seconds} seconds")
     end
@@ -124,10 +124,10 @@ module HttpLog
         method: method,
         url: url,
         request_body: request_body,
-        request_headers: request_headers,
+        request_headers: request_headers.to_h,
         response_code: response_code,
         response_body: response_body,
-        response_headers: response_headers,
+        response_headers: response_headers.to_h,
         benchmark: benchmark
       }.to_json)
     end

--- a/lib/httplog/version.rb
+++ b/lib/httplog/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HttpLog
-  VERSION = '1.1.3'.freeze
+  VERSION = '1.1.2'.freeze
 end

--- a/lib/httplog/version.rb
+++ b/lib/httplog/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HttpLog
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.1.3'.freeze
 end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -339,7 +339,7 @@ describe HttpLog do
           expect(logged_json['request_body']).to eq 'foo=bar&bar=foo'
           expect(logged_json['request_headers']).to be_a Hash
           expect(logged_json['response_headers']).to be_a Hash
-          expect(logged_json['response_code']).to eq '200'
+          expect(logged_json['response_code']).to eq 200
           expect(logged_json['response_body']).to eq "<html>\n  <head>\n    <title>Test Page</title>\n  </head>\n  <body>\n    <h1>This is the test page.</h1>\n  </body>\n</html>"
           expect(logged_json['benchmark']).to be_a Numeric
         end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -78,20 +78,25 @@ describe HttpLog do
           end
 
           context 'with binary response body' do
-            let(:path) { '/test.bin' }
-            let(:data) { nil }
+            [
+              '/test.bin',
+              '/test.pdf'
+            ].each do |response_file_name|
+              let(:path) { response_file_name }
+              let(:data) { nil }
 
-            it "doesn't log response" do
-              adapter.send_get_request
-              expect(log).to include(HttpLog::LOG_PREFIX + 'Response: (not showing binary data)')
-            end
-
-            context 'with JSON logging' do
-              before(:each) { HttpLog.configure { |c| c.json_log = true } }
               it "doesn't log response" do
                 adapter.send_get_request
-                logged_json = JSON.parse log.match(/\[httplog\]\s(.*)/).captures.first
-                expect(logged_json['response_body']).to eq '(not showing binary data)'
+                expect(log).to include(HttpLog::LOG_PREFIX + 'Response: (not showing binary data)')
+              end
+
+              context 'with JSON logging' do
+                before(:each) { HttpLog.configure { |c| c.json_log = true } }
+                it "doesn't log response" do
+                  adapter.send_get_request
+                  logged_json = JSON.parse log.match(/\[httplog\]\s(.*)/).captures.first
+                  expect(logged_json['response_body']).to eq '(not showing binary data)'
+                end
               end
             end
           end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'pry'
 
 describe HttpLog do
   let(:host) { 'localhost' }

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -330,18 +330,19 @@ describe HttpLog do
 
       context 'with JSON config' do
         before(:each) { HttpLog.configure { |c| c.json_log = true } }
+        if adapter_class.method_defined? :send_post_request
+          it 'should log a single line with JSON structure' do
+            adapter.send_post_request
+            logged_json = JSON.parse log.match(/\[httplog\]\s(.*)/).captures.first
 
-        it 'should log a single line with JSON structure' do
-          adapter.send_post_request
-          logged_json = JSON.parse log.match(/\[httplog\]\s(.*)/).captures.first
-
-          expect(logged_json['method']).to eq 'POST'
-          expect(logged_json['request_body']).to eq 'foo=bar&bar=foo'
-          expect(logged_json['request_headers']).to be_a Hash
-          expect(logged_json['response_headers']).to be_a Hash
-          expect(logged_json['response_code']).to eq 200
-          expect(logged_json['response_body']).to eq "<html>\n  <head>\n    <title>Test Page</title>\n  </head>\n  <body>\n    <h1>This is the test page.</h1>\n  </body>\n</html>"
-          expect(logged_json['benchmark']).to be_a Numeric
+            expect(logged_json['method']).to eq 'POST'
+            expect(logged_json['request_body']).to eq 'foo=bar&bar=foo'
+            expect(logged_json['request_headers']).to be_a Hash
+            expect(logged_json['response_headers']).to be_a Hash
+            expect(logged_json['response_code']).to eq 200
+            expect(logged_json['response_body']).to eq "<html>\n  <head>\n    <title>Test Page</title>\n  </head>\n  <body>\n    <h1>This is the test page.</h1>\n  </body>\n</html>"
+            expect(logged_json['benchmark']).to be_a Numeric
+          end
         end
       end
     end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -327,6 +327,23 @@ describe HttpLog do
           expect(log).to_not include(HttpLog::LOG_PREFIX + 'Benchmark: ')
         end
       end
+
+      context 'with JSON config' do
+        before(:each) { HttpLog.configure { |c| c.json_log = true } }
+
+        it 'should log a single line with JSON structure' do
+          adapter.send_post_request
+          logged_json = JSON.parse log.match(/\[httplog\]\s(.*)/).captures.first
+
+          expect(logged_json['method']).to eq 'POST'
+          expect(logged_json['request_body']).to eq 'foo=bar&bar=foo'
+          expect(logged_json['request_headers']).to be_a Hash
+          expect(logged_json['response_headers']).to be_a Hash
+          expect(logged_json['response_code']).to eq '200'
+          expect(logged_json['response_body']).to eq "<html>\n  <head>\n    <title>Test Page</title>\n  </head>\n  <body>\n    <h1>This is the test page.</h1>\n  </body>\n</html>"
+          expect(logged_json['benchmark']).to be_a Numeric
+        end
+      end
     end
   end
 end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'pry'
 
 describe HttpLog do
   let(:host) { 'localhost' }
@@ -84,6 +85,15 @@ describe HttpLog do
             it "doesn't log response" do
               adapter.send_get_request
               expect(log).to include(HttpLog::LOG_PREFIX + 'Response: (not showing binary data)')
+            end
+
+            context 'with JSON logging' do
+              before(:each) { HttpLog.configure { |c| c.json_log = true } }
+              it "doesn't log response" do
+                adapter.send_get_request
+                logged_json = JSON.parse log.match(/\[httplog\]\s(.*)/).captures.first
+                expect(logged_json['response_body']).to eq '(not showing binary data)'
+              end
             end
           end
         end

--- a/spec/support/test.pdf
+++ b/spec/support/test.pdf
@@ -1,0 +1,198 @@
+%PDF-1.3
+%‚„œ”
+
+1 0 obj
+<<
+/Type /Catalog
+/Outlines 2 0 R
+/Pages 3 0 R
+>>
+endobj
+
+2 0 obj
+<<
+/Type /Outlines
+/Count 0
+>>
+endobj
+
+3 0 obj
+<<
+/Type /Pages
+/Count 2
+/Kids [ 4 0 R 6 0 R ] 
+>>
+endobj
+
+4 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 5 0 R
+>>
+endobj
+
+5 0 obj
+<< /Length 1074 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( A Simple PDF File ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( This is a small demonstration .pdf file - ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( just for use in the Virtual Mechanics tutorials. More text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 628.8480 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 616.8960 Td
+( text. And more text. Boring, zzzzz. And more text. And more text. And ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 604.9440 Td
+( more text. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 592.9920 Td
+( And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 569.0880 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 557.1360 Td
+( text. And more text. And more text. Even more. Continued on page 2 ...) Tj
+ET
+endstream
+endobj
+
+6 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 7 0 R
+>>
+endobj
+
+7 0 obj
+<< /Length 676 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( Simple PDF File 2 ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( ...continued from page 1. Yet more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 676.6560 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( text. Oh, how boring typing this stuff. But not as boring as watching ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( paint dry. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 640.8000 Td
+( Boring.  More, a little more text. The end, and just as well. ) Tj
+ET
+endstream
+endobj
+
+8 0 obj
+[/PDF /Text]
+endobj
+
+9 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/Name /F1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+
+10 0 obj
+<<
+/Creator (Rave \(http://www.nevrona.com/rave\))
+/Producer (Nevrona Designs)
+/CreationDate (D:20060301072826)
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000019 00000 n
+0000000093 00000 n
+0000000147 00000 n
+0000000222 00000 n
+0000000390 00000 n
+0000001522 00000 n
+0000001690 00000 n
+0000002423 00000 n
+0000002456 00000 n
+0000002574 00000 n
+
+trailer
+<<
+/Size 11
+/Root 1 0 R
+/Info 10 0 R
+>>
+
+startxref
+2714
+%%EOF

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -21,6 +21,7 @@ module Httplog
 
         elsif File.exist?(file)
           headers['Content-Type'] = 'application/octet-stream' if File.extname(file) == '.bin'
+          headers['Content-Type'] = 'application/pdf' if File.extname(file) == '.pdf'
           headers['Content-Type'] = 'text/html; charset=UTF-8' if path =~ /utf8/
           headers['Content-Encoding'] = 'gzip' if File.extname(file) == '.gz'
           [200, headers, File.binread(file)]


### PR DESCRIPTION
This pull request adds the option to log HTTP requests as JSON.

**NOTE**: http4 does not support ruby < 2.3.X, so the build for that combination has been flagged as "allow_failure"