### PR TITLE
Add support for ruby 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - "2.3.8"
   - "2.4.4"
   - "2.5.2"
+  - "2.6.0"
 gemfile:
   - gemfiles/http2.gemfile
   - gemfiles/http3.gemfile


### PR DESCRIPTION
* Include ruby 2.6.0 in the test execution plan.