### PR TITLE
Fix method called on nil in the Ethon adapter when the response headers are empty

### DIFF
--- a/lib/httplog/adapters/ethon.rb
+++ b/lib/httplog/adapters/ethon.rb
@@ -28,7 +28,7 @@ if defined?(Ethon)
 
           # Hard to believe that Ethon wouldn't parse out the headers into
           # an array; probably overlooked it. Anyway, let's do it ourselves:
-          headers = response_headers.split(/\r?\n/)[1..-1]
+          headers = response_headers.split(/\r?\n/).drop(1)
 
           HttpLog.call(
             method: @http_log[:method],


### PR DESCRIPTION
Resolves https://github.com/trusche/httplog/issues/67