### PR TITLE
Round benchmark time in compact mode

### DIFF
--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -142,7 +142,7 @@ module HttpLog
     def log_compact(method, uri, status, seconds)
       return unless config.compact_log
       status = Rack::Utils.status_code(status) unless status == /\d{3}/
-      log("#{method.to_s.upcase} #{uri} completed with status code #{status} in #{seconds} seconds")
+      log("#{method.to_s.upcase} #{uri} completed with status code #{status} in #{seconds.to_f.round(6)} seconds")
     end
 
     def log_json(data = {})

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -231,7 +231,7 @@ describe HttpLog do
 
           context 'with compact config' do
             let(:compact_log) { true }
-            it { is_expected.to match(%r{\[httplog\] GET http://#{host}:#{port}#{path}(\?.*)? completed with status code \d{3} in (\d|\.)+}) }
+            it { is_expected.to match(%r{\[httplog\] GET http://#{host}:#{port}#{path}(\?.*)? completed with status code \d{3} in \d+\.\d{1,6} }) }
             it { is_expected.to_not include("Connecting: #{host}:#{port}") }
             it { is_expected.to_not include('Response:') }
             it { is_expected.to_not include('Data:') }


### PR DESCRIPTION
The benchmark time didn't have its precision capped in compact mode, generating entries like this: `... status code 200 in 0.03279600013047457 seconds`

This PRs rounds the benchmark time the same way we already round in non-compact mode: rounding to 6 decimal places.