### PR TITLE
allow specific logging of request or response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,19 @@ HttpLog.configure do |config|
   # Tweak which parts of the HTTP cycle to log...
   config.log_connect   = true
   config.log_request   = true
-  config.log_headers   = false
   config.log_data      = true
   config.log_status    = true
   config.log_response  = true
   config.log_benchmark = true
 
-  # ...or log all request as a single line by setting this to `true`
+  # You can choose to log both the response and request headers...
+  config.log_headers   = false
+
+  # ...or each one specifically
+  config.log_request_headers  = true
+  config.log_response_headers = false
+
+  # You can log all request as a single line by setting this to `true`
   config.compact_log = false
 
   # You can also log in JSON format

--- a/lib/httplog/configuration.rb
+++ b/lib/httplog/configuration.rb
@@ -10,10 +10,11 @@ module HttpLog
                   :prefix,
                   :log_connect,
                   :log_request,
-                  :log_headers,
+                  :log_request_headers,
                   :log_data,
                   :log_status,
                   :log_response,
+                  :log_response_headers,
                   :log_benchmark,
                   :url_whitelist_pattern,
                   :url_blacklist_pattern,
@@ -21,6 +22,7 @@ module HttpLog
                   :prefix_data_lines,
                   :prefix_response_lines,
                   :prefix_line_numbers
+    attr_writer   :log_headers
 
     def initialize
       @enabled               = true
@@ -31,10 +33,12 @@ module HttpLog
       @prefix                = LOG_PREFIX
       @log_connect           = true
       @log_request           = true
+      @log_request_headers   = false
       @log_headers           = false
       @log_data              = true
       @log_status            = true
       @log_response          = true
+      @log_headers_response  = false
       @log_benchmark         = true
       @url_whitelist_pattern = nil
       @url_blacklist_pattern = nil
@@ -42,6 +46,10 @@ module HttpLog
       @prefix_data_lines     = false
       @prefix_response_lines = false
       @prefix_line_numbers   = false
+    end
+
+    def log_headers
+      @log_headers && !(log_request_headers || log_response_headers)
     end
 
     # TODO: remove in 1.0.0

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -34,11 +34,11 @@ module HttpLog
         log_compact(options[:method], options[:url], options[:response_code], options[:benchmark])
       else
         HttpLog.log_request(options[:method], options[:url])
-        HttpLog.log_headers(options[:request_headers])
+        HttpLog.log_request_headers(options[:request_headers])
         HttpLog.log_data(options[:request_body])
         HttpLog.log_status(options[:response_code])
         HttpLog.log_benchmark(options[:benchmark])
-        HttpLog.log_headers(options[:response_headers])
+        HttpLog.log_response_headers(options[:response_headers])
         HttpLog.log_body(options[:response_body], options[:encoding], options[:content_type])
       end
     end
@@ -67,12 +67,16 @@ module HttpLog
       log("Sending: #{method.to_s.upcase} #{uri}")
     end
 
-    def log_headers(headers = {})
-      return unless config.log_headers
+    def log_request_headers(headers = {})
+      return unless config.log_headers || config.log_request_headers
 
-      headers.each do |key, value|
-        log("Header: #{key}: #{value}")
-      end
+      log_headers(headers)
+    end
+
+    def log_response_headers(headers = {})
+      return unless config.log_headers || config.log_response_headers
+
+      log_headers(headers)
     end
 
     def log_status(status)
@@ -196,6 +200,12 @@ module HttpLog
     end
 
     private
+
+    def log_headers(headers = {})
+      headers.each do |key, value|
+        log("Header: #{key}: #{value}")
+      end
+    end
 
     def utf_encoded(data, content_type = nil)
       charset = content_type.to_s.scan(/; charset=(\S+)/).flatten.first || 'UTF-8'

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -18,5 +18,79 @@ module HttpLog
         expect(config.compact_log).to eq(true)
       end
     end
+
+    describe '#log_headers' do
+      subject { config.log_headers }
+
+      before do
+        config.log_headers          = log_headers
+        config.log_request_headers  = log_request_headers
+        config.log_response_headers = log_response_headers
+      end
+
+      context 'when `log_headers` is true' do
+        let(:log_headers) { true }
+
+        context 'and both `log_request_headers` and `log_reponse_headers` are false' do
+          let(:log_request_headers) { false }
+          let(:log_response_headers) { false }
+
+          it { is_expected.to be_truthy }
+        end
+
+        context 'and both `log_request_headers` and `log_reponse_headers` are true' do
+          let(:log_request_headers) { true }
+          let(:log_response_headers) { true }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context 'when `log_request_headers` is true and `log_response_headers` is false' do
+          let(:log_request_headers) { true }
+          let(:log_response_headers) { false }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context 'when `log_request_headers` is false and `log_response_headers` is true' do
+          let(:log_request_headers) { false }
+          let(:log_response_headers) { true }
+
+          it { is_expected.to be_falsey }
+        end
+      end
+
+      context 'when `log_headers` is false' do
+        let(:log_headers) { false }
+
+        context 'and both `log_request_headers` and `log_reponse_headers` are false' do
+          let(:log_request_headers) { false }
+          let(:log_response_headers) { false }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context 'and both `log_request_headers` and `log_reponse_headers` are true' do
+          let(:log_request_headers) { true }
+          let(:log_response_headers) { true }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context 'when `log_request_headers` is true and `log_response_headers` is false' do
+          let(:log_request_headers) { true }
+          let(:log_response_headers) { false }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context 'when `log_request_headers` is false and `log_response_headers` is true' do
+          let(:log_request_headers) { false }
+          let(:log_response_headers) { true }
+
+          it { is_expected.to be_falsey }
+        end
+      end
+    end
   end
 end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -19,7 +19,9 @@ describe HttpLog do
   let(:severity)              { HttpLog.configuration.severity }
   let(:log_headers)           { HttpLog.configuration.log_headers }
   let(:log_request)           { HttpLog.configuration.log_request }
+  let(:log_request_headers)   { HttpLog.configuration.log_request_headers }
   let(:log_response)          { HttpLog.configuration.log_response }
+  let(:log_response_headers)  { HttpLog.configuration.log_response_headers }
   let(:log_data)              { HttpLog.configuration.log_data }
   let(:log_connect)           { HttpLog.configuration.log_connect }
   let(:log_benchmark)         { HttpLog.configuration.log_benchmark }
@@ -38,7 +40,9 @@ describe HttpLog do
       c.severity              = severity
       c.log_headers           = log_headers
       c.log_request           = log_request
+      c.log_request_headers   = log_request_headers
       c.log_response          = log_response
+      c.log_response_headers  = log_response_headers
       c.log_data              = log_data
       c.log_connect           = log_connect
       c.log_benchmark         = log_benchmark
@@ -170,10 +174,82 @@ describe HttpLog do
             it { is_expected.to include('INFO') }
           end
 
-          context 'with headers logging' do
+          context 'with headers logging enabled' do
             let(:log_headers) { true }
-            it { is_expected.to match(%r{Header: accept: */*}i) } # request
-            it { is_expected.to match(/Header: Server: thin/i) } # response
+
+            context 'and specific headers logging' do
+              context 'when only request headers logging is enabled' do
+                let(:log_request_headers) { true }
+                let(:log_response_headers) { false }
+
+                it { is_expected.to match(%r{Header: accept: */*}i) } # request
+                it { is_expected.not_to match(/Header: Server: thin/i) } # response
+              end
+
+              context 'when only response headers logging is enabled' do
+                let(:log_request_headers) { false }
+                let(:log_response_headers) { true }
+
+                it { is_expected.not_to match(%r{Header: accept: */*}i) } # request
+                it { is_expected.to match(/Header: Server: thin/i) } # response
+              end
+
+              context 'when both request and response headers logging are enabled' do
+                let(:log_request_headers) { true }
+                let(:log_response_headers) { true }
+
+                it { is_expected.to match(%r{Header: accept: */*}i) } # request
+                it { is_expected.to match(/Header: Server: thin/i) } # response
+              end
+
+              context 'when both request and response headers logging are disabled' do
+                let(:log_request_headers) { false }
+                let(:log_response_headers) { false }
+
+
+                it { is_expected.to match(%r{Header: accept: */*}i) } # request
+                it { is_expected.to match(/Header: Server: thin/i) } # response
+              end
+            end
+          end
+
+          context 'with headers logging disabled' do
+            let(:log_headers) { false }
+
+            context 'and specific headers logging' do
+              context 'when only request headers logging is enabled' do
+                let(:log_request_headers) { true }
+                let(:log_response_headers) { false }
+
+                it { is_expected.to match(%r{Header: accept: */*}i) } # request
+                it { is_expected.not_to match(/Header: Server: thin/i) } # response
+              end
+
+              context 'when only response headers logging is enabled' do
+                let(:log_request_headers) { false }
+                let(:log_response_headers) { true }
+
+                it { is_expected.not_to match(%r{Header: accept: */*}i) } # request
+                it { is_expected.to match(/Header: Server: thin/i) } # response
+              end
+
+              context 'when both request and response headers logging are enabled' do
+                let(:log_request_headers) { true }
+                let(:log_response_headers) { true }
+
+                it { is_expected.to match(%r{Header: accept: */*}i) } # request
+                it { is_expected.to match(/Header: Server: thin/i) } # response
+              end
+
+              context 'when both request and response headers logging are disabled' do
+                let(:log_request_headers) { false }
+                let(:log_response_headers) { false }
+
+
+                it { is_expected.not_to match(%r{Header: accept: */*}i) } # request
+                it { is_expected.not_to match(/Header: Server: thin/i) } # response
+              end
+            end
           end
 
           context 'with blacklist hit' do


### PR DESCRIPTION
Hello friends!

We found a use case where we only wanted to log the request headers of an API call.
Currently, this gem doesn't differentiate between request and response headers, so it's impossible to configure it to log only the required headers in our use case.

This PR allows the configuration of either request and or response headers by introducing the following configuration attributes:

```ruby
HttpLog.configure do |config|
  config.log_request_headers  = true
  config.log_response_headers = false
end
```

It keeps the existing `config.log_headers` configuration and default both of the new config values as **false** to maintain backwards compatibility with the current gem version.

The following behaviour was introduced:
- when `log_headers` is enabled and both `log_request_headers` and `log_response_headers` are false, **it logs both the request and response headers**.
- when `log_headers` is enabled and one of the new configs is enable, **it logs only the enabled config headers**
- when `log_headers`, `log_request_headers` and `log_response_headers` are disabled, **it doesn't log any headers**.

Thanks for considering this and sorry if this is not the required flow to make a feature request to this repo. If the later is the case, please give me some feedback so I can adequate (or close) this PR.

Cheers!