### PR TITLE
Mask sensitive information

### DIFF
--- a/lib/httplog/configuration.rb
+++ b/lib/httplog/configuration.rb
@@ -20,7 +20,8 @@ module HttpLog
                   :color,
                   :prefix_data_lines,
                   :prefix_response_lines,
-                  :prefix_line_numbers
+                  :prefix_line_numbers,
+                  :filtered_keywords
 
     def initialize
       @enabled               = true
@@ -42,6 +43,7 @@ module HttpLog
       @prefix_data_lines     = false
       @prefix_response_lines = false
       @prefix_line_numbers   = false
+      @filtered_keywords     = []
     end
 
     # TODO: remove in 1.0.0

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -105,6 +105,8 @@ module HttpLog
     end
 
     def masked_data(msg)
+      return msg if config.filtered_keywords.nil? || config.filtered_keywords.empty?
+
       case msg
       when String, HTTP::URI, Addressable::URI
         begin

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -177,19 +177,19 @@ module HttpLog
       if config.compact_log
         log({
           method: data[:method].to_s.upcase,
-          url: data[:url],
+          url: filter_out(data[:url]),
           response_code: data[:response_code].to_i,
           benchmark: data[:benchmark]
         }.to_json)
       else
         log({
           method: data[:method].to_s.upcase,
-          url: data[:url],
-          request_body: data[:request_body],
-          request_headers: data[:request_headers].to_h,
+          url: filter_out(data[:url]),
+          request_body: filter_out(data[:request_body]),
+          request_headers: filter_out_hash(data[:request_headers].to_h),
           response_code: data[:response_code].to_i,
-          response_body: parsed_body,
-          response_headers: data[:response_headers].to_h,
+          response_body: filter_out(parsed_body),
+          response_headers: filter_out_hash(data[:response_headers].to_h),
           benchmark: data[:benchmark]
         }.to_json)
       end

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -65,13 +65,13 @@ module HttpLog
     def log_request(method, uri)
       return unless config.log_request
 
-      log("Sending: #{method.to_s.upcase} #{filter_out(uri)}")
+      log("Sending: #{method.to_s.upcase} #{masked_data(uri)}")
     end
 
     def log_headers(headers = {})
       return unless config.log_headers
 
-      filter_out(headers).each do |key, value|
+      masked_data(headers).each do |key, value|
         log("Header: #{key}: #{value}")
       end
     end
@@ -96,15 +96,15 @@ module HttpLog
 
       if config.prefix_response_lines
         log('Response:')
-        log_data_lines(filter_out(data))
+        log_data_lines(masked_data(data))
       else
-        log("Response:\n#{filter_out(data)}")
+        log("Response:\n#{masked_data(data)}")
       end
     rescue BodyParsingError => e
       log("Response: #{e.message}")
     end
 
-    def filter_out(msg)
+    def masked_data(msg)
       case msg
       when String, HTTP::URI, Addressable::URI
         config.filtered_keywords.reduce(msg) do |acc, keyword|
@@ -155,9 +155,9 @@ module HttpLog
 
       if config.prefix_data_lines
         log('Data:')
-        log_data_lines(filter_out(data))
+        log_data_lines(masked_data(data))
       else
-        log("Data: #{filter_out(data)}")
+        log("Data: #{masked_data(data)}")
       end
     end
 
@@ -181,19 +181,19 @@ module HttpLog
       if config.compact_log
         log({
           method: data[:method].to_s.upcase,
-          url: filter_out(data[:url]),
+          url: masked_data(data[:url]),
           response_code: data[:response_code].to_i,
           benchmark: data[:benchmark]
         }.to_json)
       else
         log({
           method: data[:method].to_s.upcase,
-          url: filter_out(data[:url]),
-          request_body: filter_out(data[:request_body]),
-          request_headers: filter_out(data[:request_headers].to_h),
+          url: masked_data(data[:url]),
+          request_body: masked_data(data[:request_body]),
+          request_headers: masked_data(data[:request_headers].to_h),
           response_code: data[:response_code].to_i,
-          response_body: filter_out(parsed_body),
-          response_headers: filter_out(data[:response_headers].to_h),
+          response_body: masked_data(parsed_body),
+          response_headers: masked_data(data[:response_headers].to_h),
           benchmark: data[:benchmark]
         }.to_json)
       end

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -116,6 +116,8 @@ module HttpLog
     end
 
     def filter_out_hash(hash)
+      hash = hash.to_h
+      (hash.keys & config.filtered_keywords).each{ | keyword| hash[keyword] = '[FILTERED]' }
       hash
     end
 

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -330,7 +330,18 @@ describe HttpLog do
         context 'GET' do
           before { adapter.send_get_request }
           it_behaves_like 'filters out keywords'
-        end        
+        end
+
+        context 'with JSON logging' do
+          let(:json_log) { true }
+
+          context 'POST' do
+            if adapter_class.method_defined? :send_post_request
+              before { adapter.send_post_request }
+              it_behaves_like 'filters out keywords'
+            end
+          end
+        end
       end
     end
   end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -342,6 +342,26 @@ describe HttpLog do
             end
           end
         end
+
+        context 'with JSON body' do
+          [
+            { foo: :bar, secret: :key_1, password: :key_2 },
+            { foo: { secret: :key_1, password: :key_2 } },
+            { foo: [{ secret: :key_1 }, { password: :key_2 } ] },
+            { a: { b: {c: { d: { secret: :key_1, password: :key_2 } } } } },
+            { a: [ b: { c: [ d: { secret: :key_1, password: :key_2 } ] } ] },
+            [ { foo: :bar }, { secret: :key_1 }, { password: :key_2 } ]
+          ].each_with_index do |body, i|
+            context "example #{i}" do
+              let(:data) { body.to_json }
+
+              if adapter_class.method_defined? :send_post_request
+                before { adapter.send_post_request }
+                it_behaves_like 'filters out keywords'
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -311,6 +311,7 @@ describe HttpLog do
 
       context 'with filtered keywords' do
         let(:filtered_keywords) { %w(secret password) }
+        let(:log_headers) { true }
 
         context 'POST' do
           if adapter_class.method_defined? :send_post_request

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -8,9 +8,9 @@ describe HttpLog do
   let(:host)    { 'localhost' }
   let(:port)    { 9292 }
   let(:path)    { '/index.html' }
-  let(:headers) { { 'accept' => '*/*', 'foo' => 'bar' } }
-  let(:data)    { 'foo=bar&bar=foo' }
-  let(:params)  { { 'foo' => 'bar:form-data', 'bar' => 'foo' } }
+  let(:headers) { { 'accept' => '*/*', 'foo' => 'bar', 'secret' => '1234', 'password' => '5678' } }
+  let(:data)    { 'foo=bar&bar=foo&secret=1234&password=5678' }
+  let(:params)  { { 'foo' => 'bar:form-data', 'bar' => 'foo', 'secret' => '1234', 'password' => '5678' } }
   let(:html)    { File.read('./spec/support/index.html') }
   let(:json)    { JSON.parse(log.match(/\[httplog\]\s(.*)/).captures.first) }
 
@@ -310,7 +310,26 @@ describe HttpLog do
       end
 
       context 'with filtered keywords' do
+        let(:filtered_keywords) { %w(secret password) }
 
+        context 'POST' do
+          if adapter_class.method_defined? :send_post_request
+            before { adapter.send_post_request }
+            it_behaves_like 'filters out keywords'
+          end
+        end
+
+        context 'POST form' do
+          if adapter_class.method_defined? :send_post_form_request
+            before { adapter.send_post_form_request }
+            it_behaves_like 'filters out keywords'
+          end
+        end
+
+        context 'GET' do
+          before { adapter.send_get_request }
+          it_behaves_like 'filters out keywords'
+        end        
       end
     end
   end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -31,6 +31,7 @@ describe HttpLog do
   let(:compact_log)           { HttpLog.configuration.compact_log }
   let(:url_blacklist_pattern) { HttpLog.configuration.url_blacklist_pattern }
   let(:url_whitelist_pattern) { HttpLog.configuration.url_whitelist_pattern }
+  let(:filtered_keywords)     { HttpLog.configuration.filtered_keywords }
 
   def configure
     HttpLog.configure do |c|
@@ -50,6 +51,7 @@ describe HttpLog do
       c.compact_log           = compact_log
       c.url_blacklist_pattern = url_blacklist_pattern
       c.url_whitelist_pattern = url_whitelist_pattern
+      c.filtered_keywords     = filtered_keywords
     end
   end
 
@@ -305,6 +307,10 @@ describe HttpLog do
             it { expect(json['benchmark']).to be_a(Numeric) }
           end
         end
+      end
+
+      context 'with filtered keywords' do
+
       end
     end
   end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -8,9 +8,9 @@ describe HttpLog do
   let(:host)    { 'localhost' }
   let(:port)    { 9292 }
   let(:path)    { '/index.html' }
-  let(:headers) { { 'accept' => '*/*', 'foo' => 'bar', 'secret' => '1234', 'password' => '5678' } }
-  let(:data)    { 'foo=bar&bar=foo&secret=1234&password=5678' }
-  let(:params)  { { 'foo' => 'bar:form-data', 'bar' => 'foo', 'secret' => '1234', 'password' => '5678' } }
+  let(:headers) { { 'accept' => '*/*', 'foo' => 'bar', 'secret' => 'key_1', 'password' => 'key_2' } }
+  let(:data)    { 'foo=bar&bar=foo&secret=key_1&password=key_2' }
+  let(:params)  { { 'foo' => 'bar:form-data', 'bar' => 'foo', 'secret' => 'key_1', 'password' => 'key_2' } }
   let(:html)    { File.read('./spec/support/index.html') }
   let(:json)    { JSON.parse(log.match(/\[httplog\]\s(.*)/).captures.first) }
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -61,3 +61,8 @@ RSpec.shared_examples 'with connection logging disabled' do
   let(:log_connect) { false }
   it { is_expected.to_not include('Connecting:') }
 end
+
+RSpec.shared_examples 'filters out keywords' do
+  it { is_expected.to_not include('secret=1234') }
+  it { is_expected.to_not include('password=5678') }
+end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -63,8 +63,6 @@ RSpec.shared_examples 'with connection logging disabled' do
 end
 
 RSpec.shared_examples 'filters out keywords' do
-  it { is_expected.to_not include('secret=1234') }
-  it { is_expected.to_not include('secret: 1234') }
-  it { is_expected.to_not include('password=5678') }
-  it { is_expected.to_not include('password: 5678') }
+  it { is_expected.to_not include('key_1') }
+  it { is_expected.to_not include('key_2') }
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -64,5 +64,7 @@ end
 
 RSpec.shared_examples 'filters out keywords' do
   it { is_expected.to_not include('secret=1234') }
+  it { is_expected.to_not include('secret: 1234') }
   it { is_expected.to_not include('password=5678') }
+  it { is_expected.to_not include('password: 5678') }
 end


### PR DESCRIPTION
We need to mask some sensitive information such as credentials and API tokens. 