### PR TITLE
Add logger_method config to allow more flexible logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ HttpLog.configure do |config|
   # Enable or disable all logging
   config.enabled = true
 
-  # You can assign a different logger
+  # You can assign a different logger or method to call on that logger
   config.logger = Logger.new($stdout)
+  config.logger_method = :log
 
   # I really wouldn't change this...
   config.severity = Logger::Severity::DEBUG
@@ -96,6 +97,9 @@ HttpLog.configure do |config|
   config.logger = Rails.logger
 end
 ```
+
+If you're running a (hopefully patched) legacy Rails 3 app, you may need to set
+`config.logger_method = :add` due to its somewhat unusual logger.
 
 You can colorize the output to make it stand out in your logfile, either with a single color
 for the text:

--- a/lib/httplog/configuration.rb
+++ b/lib/httplog/configuration.rb
@@ -6,6 +6,7 @@ module HttpLog
                   :compact_log,
                   :json_log,
                   :logger,
+                  :logger_method,
                   :severity,
                   :prefix,
                   :log_connect,
@@ -28,6 +29,7 @@ module HttpLog
       @compact_log           = false
       @json_log              = false
       @logger                = Logger.new($stdout)
+      @logger_method         = :log
       @severity              = Logger::Severity::DEBUG
       @prefix                = LOG_PREFIX
       @log_connect           = true

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -53,7 +53,7 @@ module HttpLog
     def log(msg)
       return unless config.enabled
 
-      config.logger.log(config.severity, colorize(prefix + msg))
+      config.logger.public_send(config.logger_method, config.severity, colorize(prefix + msg))
     end
 
     def log_connection(host, port = nil)


### PR DESCRIPTION
This allows httplog to work with a wider variety of logger
implementations as long as they have a method that takes
(severity, message).

It also enables compatibility with old Rails 3 apps where the
BufferedLogger has `add()` instead of `log()` (see #48).