### PR TITLE
Mask secrets inside XML requests and responses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,25 @@ PATH
   remote: .
   specs:
     httplog (1.3.2)
+      activesupport
+      builder
       rack (>= 1.0)
       rainbow (>= 2.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.1, >= 2.1.8)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    builder (3.2.3)
     coderay (1.1.2)
+    concurrent-ruby (1.1.5)
     daemons (1.3.1)
     diff-lcs (1.3)
     docile (1.3.2)
@@ -51,6 +61,8 @@ GEM
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
     json (2.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -61,6 +73,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
+    minitest (5.11.3)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
@@ -103,9 +116,13 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thor (0.20.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
+    zeitwerk (2.1.9)
 
 PLATFORMS
   ruby

--- a/httplog.gemspec
+++ b/httplog.gemspec
@@ -40,4 +40,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rack', ['>= 1.0']
   gem.add_dependency 'rainbow', ['>= 2.0.0']
+  gem.add_dependency 'activesupport'
+  gem.add_dependency 'builder'
 end

--- a/spec/support/index.html
+++ b/spec/support/index.html
@@ -4,5 +4,6 @@
   </head>
   <body>
     <h1>This is the test page.</h1>
+    <foo>This is my secret</foo>
   </body>
 </html>


### PR DESCRIPTION
### What

In some circumstances, secrets are sent inside XML request and responses instead of using HTTP headers. The traces of these requests need to mask the configured secrets to avoid the exposure of sensitive information. 

### How

- Wrap the masking of Strings using a method that transforms XMLs into hashes before masking, and back to Strings after masking is done.
- Using the `masked` method in the `parse_body` method.