### PR TITLE
Rework Graylog support. Allow different Graylog log formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,38 @@ HttpLog.configure do |config|
 end
 ```
 
+For more color options please refer to the [rainbow documentation](https://github.com/sickill/rainbow)
+
+### Graylog logging
+
 If you use Graylog and want to use its search features such as "benchmark:>1 AND method:PUT",
 you can use this configuration:
 
 ```ruby
+FORMATTER = Lograge::Formatters::KeyValue.new
+
 HttpLog.configure do |config|
-  config.logger        = <your GELF::Logger>
-  config.logger_method = :add
-  config.severity      = GELF::Levels::DEBUG
-  config.graylog       = true
+  config.logger            = <your GELF::Logger>
+  config.logger_method     = :add
+  config.severity          = GELF::Levels::DEBUG
+  config.graylog_formatter = FORMATTER
 end
 ```
 
-For more color options please refer to the [rainbow documentation](https://github.com/sickill/rainbow)
+You also can use GELF Graylog format this way:
+
+```ruby
+class Lograge::Formatters::Graylog2HttpLog < Lograge::Formatters::Graylog2
+  def short_message data
+    data[:response_body] = data[:response_body].to_s.byteslice(0, 32_766) unless data[:response_body].blank?
+    "[httplog] [#{data[:response_code]}] #{data[:method]} #{data[:url]}"
+  end
+end
+
+FORMATTER = Lograge::Formatters::Graylog2HttpLog.new
+```
+
+Or define your own class that implements the `call` method
 
 ### Compact logging
 

--- a/lib/httplog/configuration.rb
+++ b/lib/httplog/configuration.rb
@@ -5,7 +5,7 @@ module HttpLog
     attr_accessor :enabled,
                   :compact_log,
                   :json_log,
-                  :graylog,
+                  :graylog_formatter,
                   :logger,
                   :logger_method,
                   :severity,
@@ -31,7 +31,7 @@ module HttpLog
       @enabled                 = true
       @compact_log             = false
       @json_log                = false
-      @graylog                 = false
+      @graylog_formatter       = nil
       @logger                  = Logger.new($stdout)
       @logger_method           = :log
       @severity                = Logger::Severity::DEBUG

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -32,7 +32,7 @@ module HttpLog
       parse_request(options)
       if config.json_log
         log_json(options)
-      elsif config.graylog
+      elsif config.graylog_formatter
         log_graylog(options)
       elsif config.compact_log
         log_compact(options[:method], options[:url], options[:response_code], options[:benchmark])
@@ -207,8 +207,6 @@ module HttpLog
 
     def log_graylog(data)
       result = json_payload(data)
-
-      result[:short_message] = result.delete(:url)
       begin
         send_to_graylog result
       rescue
@@ -219,7 +217,8 @@ module HttpLog
     end
 
     def send_to_graylog data
-      config.logger.public_send(config.logger_method, config.severity, data)
+      data.compact!
+      config.logger.public_send(config.logger_method, config.severity, config.graylog_formatter.call(data))
     end
 
     def json_payload(data = {})

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -31,7 +31,7 @@ describe HttpLog do
   let(:prefix_response_lines)   { HttpLog.configuration.prefix_response_lines }
   let(:prefix_line_numbers)     { HttpLog.configuration.prefix_line_numbers }
   let(:json_log)                { HttpLog.configuration.json_log }
-  let(:graylog)                 { HttpLog.configuration.graylog }
+  let(:graylog_formatter)       { HttpLog.configuration.graylog_formatter }
   let(:compact_log)             { HttpLog.configuration.compact_log }
   let(:url_blacklist_pattern)   { HttpLog.configuration.url_blacklist_pattern }
   let(:url_whitelist_pattern)   { HttpLog.configuration.url_whitelist_pattern }
@@ -55,7 +55,7 @@ describe HttpLog do
       c.prefix_response_lines = prefix_response_lines
       c.prefix_line_numbers   = prefix_line_numbers
       c.json_log              = json_log
-      c.graylog               = graylog
+      c.graylog_formatter     = graylog_formatter
       c.compact_log           = compact_log
       c.url_blacklist_pattern = url_blacklist_pattern
       c.url_whitelist_pattern = url_whitelist_pattern
@@ -313,7 +313,7 @@ describe HttpLog do
       end
 
       context 'with Graylog config' do
-        let(:graylog) { true }
+        let(:graylog_formatter) { Formatter.new }
         let(:logger) { GelfMock.new @log }
 
         it_behaves_like 'logs JSON', adapter_class, true

--- a/spec/loggers/formatter.rb
+++ b/spec/loggers/formatter.rb
@@ -1,0 +1,5 @@
+class Formatter
+  def call(data)
+    data
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ SimpleCov.start
 
 require 'httplog'
 
+require 'loggers/formatter'
 require 'loggers/gelf_mock'
 require 'adapters/http_base_adapter'
 Dir[File.dirname(__FILE__) + '/adapters/*.rb'].each { |f| require f }


### PR DESCRIPTION
Hello @trusche ,
The Graylog adaptation has been redesigned because it does not currently meet the Graylog GELF specification:

> \_[additional field]string (UTF-8) or number
> every field you send and prefix with an underscore (\_) 
> https://docs.graylog.org/en/3.1/pages/gelf.html

Also, these changes allow you to choose the syslog format instead of GELF.
