### PR TITLE
Fix: Response empty for HTTP gem

### DIFF
--- a/spec/adapters/ethon_adapter.rb
+++ b/spec/adapters/ethon_adapter.rb
@@ -6,21 +6,31 @@ class EthonAdapter < HTTPBaseAdapter
     easy = Ethon::Easy.new
     easy.http_request(parse_uri(true).to_s, :get, headers: @headers)
     easy.perform
+
+    easy
   end
 
   def send_head_request
     easy = Ethon::Easy.new
     easy.http_request(parse_uri.to_s, :head, headers: @headers)
     easy.perform
+
+    easy
   end
 
   def send_post_request
     easy = Ethon::Easy.new
     easy.http_request(parse_uri.to_s, :post, headers: @headers, body: @data)
     easy.perform
+
+    easy
   end
 
   def self.is_libcurl?
     true
+  end
+
+  def self.response_string_for(response)
+    response.response_body
   end
 end

--- a/spec/adapters/excon_adapter.rb
+++ b/spec/adapters/excon_adapter.rb
@@ -13,4 +13,8 @@ class ExconAdapter < HTTPBaseAdapter
   def send_post_request
     Excon.post(parse_uri.to_s, body: @data, headers: @headers)
   end
+
+  def self.response_string_for(response)
+    response.body
+  end
 end

--- a/spec/adapters/faraday_adapter.rb
+++ b/spec/adapters/faraday_adapter.rb
@@ -46,6 +46,10 @@ class FaradayAdapter < HTTPBaseAdapter
     false
   end
 
+  def self.response_string_for(response)
+    response.body
+  end
+
   private
 
   def connection

--- a/spec/adapters/http_base_adapter.rb
+++ b/spec/adapters/http_base_adapter.rb
@@ -29,11 +29,28 @@ class HTTPBaseAdapter
     "\n<html>"
   end
 
+  def expected_full_response_body
+    <<-HTML.gsub(/^      /, "").strip
+      <html>
+        <head>
+          <title>Test Page</title>
+        </head>
+        <body>
+          <h1>This is the test page.</h1>
+        </body>
+      </html>
+    HTML
+  end
+
   def self.is_libcurl?
     false
   end
 
   def self.should_log_headers?
     true
+  end
+
+  def self.response_string_for(response)
+    response.to_s
   end
 end

--- a/spec/adapters/httpclient_adapter.rb
+++ b/spec/adapters/httpclient_adapter.rb
@@ -28,4 +28,8 @@ class HTTPClientAdapter < HTTPBaseAdapter
   def logs_form_data?
     false
   end
+
+  def self.response_string_for(response)
+    response.body
+  end
 end

--- a/spec/adapters/net_http_adapter.rb
+++ b/spec/adapters/net_http_adapter.rb
@@ -18,4 +18,8 @@ class NetHTTPAdapter < HTTPBaseAdapter
   def send_post_form_request
     Net::HTTP.post_form(parse_uri, @params)
   end
+
+  def self.response_string_for(response)
+    response.body
+  end
 end

--- a/spec/adapters/open_uri_adapter.rb
+++ b/spec/adapters/open_uri_adapter.rb
@@ -16,4 +16,8 @@ class OpenUriAdapter < HTTPBaseAdapter
   def logs_data?
     false
   end
+
+  def self.response_string_for(response)
+    response.string
+  end
 end

--- a/spec/adapters/patron_adapter.rb
+++ b/spec/adapters/patron_adapter.rb
@@ -33,4 +33,8 @@ class PatronAdapter < HTTPBaseAdapter
   def self.is_libcurl?
     true
   end
+
+  def self.response_string_for(response)
+    response.body
+  end
 end

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -14,7 +14,7 @@ describe HttpLog do
   let(:params)  { { 'foo' => secret, 'bar' => 'foo:form-data' } }
   let(:html)    { File.read('./spec/support/index.html') }
   let(:json)    { JSON.parse(log.match(/\[httplog\]\s(.*)/).captures.first) }
-  let(:gray_log) { JSON.parse("{#{log.match(/{(.*)/).captures.first}") }
+  let(:gray_log) { JSON.parse("{#{log.match(/\{(.*)/).captures.first}") }
 
   # Default configuration
   let(:logger)                  { Logger.new @log }
@@ -101,6 +101,11 @@ describe HttpLog do
 
           it { expect(res).to be_a adapter.response if adapter.respond_to? :response }
 
+          it "does not alter adapter response" do
+            response_string = adapter.class.response_string_for(res)
+            expect(response_string).to eq(adapter.expected_full_response_body)
+          end
+
           context 'with gzip encoding' do
             let(:path) { '/index.html.gz' }
             let(:data) { nil }
@@ -154,6 +159,11 @@ describe HttpLog do
             it { is_expected.to_not include('Header:') }
 
             it { expect(res).to be_a adapter.response if adapter.respond_to? :response }
+
+            it "does not alter adapter response" do
+              response_string = adapter.class.response_string_for(res)
+              expect(response_string).to eq(adapter.expected_full_response_body)
+            end
 
             context 'with non-UTF request data' do
               let(:data) { "a UTF-8 striñg with an 8BIT-ASCII character: \xC3" }
@@ -378,6 +388,11 @@ describe HttpLog do
           let(:json_log) { true }
 
           it { expect(res).to be_a adapter.response if adapter.respond_to? :response }
+
+          it "does not alter adapter response" do
+            response_string = adapter.class.response_string_for(res)
+            expect(response_string).to eq(adapter.expected_full_response_body)
+          end
 
           context 'with non-UTF request data' do
             let(:data) { "a UTF-8 striñg with an 8BIT-ASCII character: \xC3" }


### PR DESCRIPTION
Fixes #89.

- I've added specs for that.
- `dup` deeper when needed, so we save some bits