### PR TITLE
Mention prefix configuration in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ HttpLog.configure do |config|
 
   # Mask the values of sensitive request parameters
   config.filter_parameters = %w[password]
+  
+  # Customize the prefix with a proc or lambda
+  confix.prefix = ->{ "[httplog] #{Time.now} " }
 end
 ```
 


### PR DESCRIPTION
Hi there! Thanks for the gem!

Digging into the source code I realized [the prefix is customizable](https://github.com/trusche/httplog/blob/v1.4.2/lib/httplog/http_log.rb#L357-L363). Hence I thought it would be nice to mention that in the README. What do you think?