### PR TITLE
Fix HEAD requests with Ruby 2.7 for NetHTTP, HTTParty, Faraday

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -1,0 +1,44 @@
+# This workflow integrates Brakeman with GitHub's Code Scanning feature
+# Brakeman is a static analysis security vulnerability scanner for Ruby on Rails applications
+
+name: Brakeman Scan
+
+# This section configures the trigger for the workflow. Feel free to customize depending on your convention
+on:
+  push:
+    branches: [ "master", "main" ]
+  pull_request:
+    branches: [ "master", "main" ]
+
+jobs:
+  brakeman-scan:
+    name: Brakeman Scan
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # Customize the ruby version depending on your needs
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+
+    - name: Setup Brakeman
+      env:
+        BRAKEMAN_VERSION: '4.10' # SARIF support is provided in Brakeman version 4.10+
+      run: |
+        gem install brakeman --version $BRAKEMAN_VERSION
+
+    # Execute Brakeman CLI and generate a SARIF output with the security issues identified during the analysis
+    - name: Scan
+      continue-on-error: true
+      run: |
+        brakeman -f sarif -o output.sarif.json .
+
+    # Upload the SARIF file generated in the previous step
+    - name: Upload SARIF
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: output.sarif.json

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -122,9 +122,11 @@ module HttpLog
       end
 
       body = body.to_s if defined?(HTTP::Response::Body) && body.is_a?(HTTP::Response::Body)
+      return nil if body.nil? || body.empty?
+
       body = body.dup
 
-      if encoding =~ /gzip/ && body && !body.empty?
+      if encoding =~ /gzip/
         begin
           sio = StringIO.new(body.to_s)
           gz = Zlib::GzipReader.new(sio)
@@ -136,7 +138,7 @@ module HttpLog
 
       result = utf_encoded(body.to_s, content_type)
 
-      if mask_body && body && !body.empty?
+      if mask_body
         if content_type =~ /json/
           result = begin
                      masked_data config.json_parser.load(result)

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -115,6 +115,7 @@ describe HttpLog do
 
             if adapter_class.method_defined? :send_head_request
               it "doesn't try to decompress body for HEAD requests" do
+                adapter.send_head_request
                 expect(log).to include('Response:')
               end
             end

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -18,7 +18,10 @@ module Httplog
 
         if params['redirect']
           [301, { 'Location' => '/index.html' }, '']
-
+        elsif env[Rack::REQUEST_METHOD] == Rack::HEAD
+          [
+            200, headers, Rack::BodyProxy.new([])
+          ]
         elsif File.exist?(file)
           headers['Content-Type'] = 'application/octet-stream' if File.extname(file) == '.bin'
           headers['Content-Type'] = 'application/pdf' if File.extname(file) == '.pdf'


### PR DESCRIPTION
Currently with Ruby 2.7 we have the following error (Because nil.to_s returns frozen string):
ERROR -- : Exception FrozenError: can't modify frozen String: ""
        /Users/vladimirkitaev/.rvm/gems/ruby-2.7.1/gems/httplog-1.4.3/lib/httplog/http_log.rb:334:in `force_encoding'
        /Users/vladimirkitaev/.rvm/gems/ruby-2.7.1/gems/httplog-1.4.3/lib/httplog/http_log.rb:334:in `rescue in utf_encoded'
        /Users/vladimirkitaev/.rvm/gems/ruby-2.7.1/gems/httplog-1.4.3/lib/httplog/http_log.rb:331:in `utf_encoded'
        /Users/vladimirkitaev/.rvm/gems/ruby-2.7.1/gems/httplog-1.4.3/lib/httplog/http_log.rb:137:in `parse_body'
        /Users/vladimirkitaev/.rvm/gems/ruby-2.7.1/gems/httplog-1.4.3/lib/httplog/http_log.rb:102:in `log_body'
        /Users/vladimirkitaev/.rvm/gems/ruby-2.7.1/gems/httplog-1.4.3/lib/httplog/http_log.rb:46:in `call'
        /Users/vladimirkitaev/.rvm/gems/ruby-2.7.1/gems/httplog-1.4.3/lib/httplog/adapters/net_http.rb:16:in `request'
        /Users/vladimirkitaev/.rvm/gems/ruby-2.7.1/gems/rest-client-2.1.0/lib/restclient/request.rb:473:in `net_http_do_request'