### PR TITLE
Remove runtime dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     httplog (1.4.3)
       rack (>= 1.0)
-      rainbow (>= 2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -136,6 +135,7 @@ DEPENDENCIES
   listen (~> 3.0)
   oj (>= 3.9.2)
   patron (~> 0.12)
+  rainbow (>= 2.0.0)
   rake (~> 13.0)
   rest-client (~> 2.0)
   rspec (~> 3.7)

--- a/httplog.gemspec
+++ b/httplog.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rest-client', ['~> 2.0']
   gem.add_development_dependency 'listen', ['~> 3.0']
   gem.add_development_dependency 'patron', ['~> 0.12']
+  gem.add_development_dependency 'rainbow', ['>= 2.0.0']
   gem.add_development_dependency 'rake', ['~> 13.0']
   gem.add_development_dependency 'rspec', ['~> 3.7']
   gem.add_development_dependency 'simplecov', ['~> 0.15']
@@ -41,5 +42,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'oj', ['>= 3.9.2']
 
   gem.add_dependency 'rack', ['>= 1.0']
-  gem.add_dependency 'rainbow', ['>= 2.0.0']
 end

--- a/lib/httplog/configuration.rb
+++ b/lib/httplog/configuration.rb
@@ -50,7 +50,7 @@ module HttpLog
       @prefix_data_lines       = false
       @prefix_response_lines   = false
       @prefix_line_numbers     = false
-      @json_parser             = JSON
+      @json_parser             = nil
       @filter_parameters       = %w[password]
     end
   end

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -26,6 +26,7 @@ module HttpLog
 
     def configure
       yield(configuration)
+      configuration.json_parser ||= ::JSON if configuration.json_log || configuration.url_masked_body_pattern
     end
 
     def call(options = {})


### PR DESCRIPTION
Resolving https://github.com/trusche/httplog/issues/106
Moving Rainbow to dev dependencies is a kind of NBC change, because people who use the color function must explicitly add it to their Gemfile