### PR TITLE
Fix empty body logging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     httplog (1.4.3)
       rack (>= 1.0)
+      rainbow (>= 2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -135,7 +136,6 @@ DEPENDENCIES
   listen (~> 3.0)
   oj (>= 3.9.2)
   patron (~> 0.12)
-  rainbow (>= 2.0.0)
   rake (~> 13.0)
   rest-client (~> 2.0)
   rspec (~> 3.7)
@@ -143,4 +143,4 @@ DEPENDENCIES
   thin (~> 1.7)
 
 BUNDLED WITH
-   2.1.4
+   2.2.21

--- a/httplog.gemspec
+++ b/httplog.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rest-client', ['~> 2.0']
   gem.add_development_dependency 'listen', ['~> 3.0']
   gem.add_development_dependency 'patron', ['~> 0.12']
-  gem.add_development_dependency 'rainbow', ['>= 2.0.0']
   gem.add_development_dependency 'rake', ['~> 13.0']
   gem.add_development_dependency 'rspec', ['~> 3.7']
   gem.add_development_dependency 'simplecov', ['~> 0.15']
@@ -42,4 +41,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'oj', ['>= 3.9.2']
 
   gem.add_dependency 'rack', ['>= 1.0']
+  gem.add_dependency 'rainbow', ['>= 2.0.0']
 end

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -350,7 +350,7 @@ module HttpLog
     end
 
     def log_data_lines(data)
-      data.each_line.with_index do |line, row|
+      data.to_s.each_line.with_index do |line, row|
         if config.prefix_line_numbers
           log("#{row + 1}: #{line.chomp}")
         else

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -28,6 +28,7 @@ describe HttpLog do
   let(:log_benchmark)           { HttpLog.configuration.log_benchmark }
   let(:color)                   { HttpLog.configuration.color }
   let(:prefix)                  { HttpLog.configuration.prefix }
+  let(:prefix_data_lines)       { HttpLog.configuration.prefix_data_lines }
   let(:prefix_response_lines)   { HttpLog.configuration.prefix_response_lines }
   let(:prefix_line_numbers)     { HttpLog.configuration.prefix_line_numbers }
   let(:json_log)                { HttpLog.configuration.json_log }
@@ -52,6 +53,7 @@ describe HttpLog do
       c.log_benchmark         = log_benchmark
       c.color                 = color
       c.prefix                = prefix
+      c.prefix_data_lines     = prefix_data_lines
       c.prefix_response_lines = prefix_response_lines
       c.prefix_line_numbers   = prefix_line_numbers
       c.json_log              = json_log
@@ -254,6 +256,22 @@ describe HttpLog do
             let(:prefix) { -> { '[custom prefix]' } }
             it { is_expected.to include('[custom prefix]') }
             it { is_expected.to_not include(HttpLog::LOG_PREFIX) }
+          end
+
+          context 'with prefix_data_lines enabled' do
+            let(:prefix_data_lines) { true }
+            it { is_expected.to include("[httplog] Data:\n") }
+          end
+
+          context 'with prefix_response_lines enabled' do
+            let(:prefix_response_lines) { true }
+            it { is_expected.to include('[httplog] <head>') }
+            it { is_expected.to include('[httplog] <title>Test Page</title>') }
+
+            context 'and blank response' do
+              let(:path) { '/empty.txt' }
+              it { is_expected.to include("[httplog] Response:\n") }
+            end
           end
 
           context 'with compact config' do

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -263,14 +263,17 @@ describe HttpLog do
             it { is_expected.to include("[httplog] Data:\n") }
           end
 
-          context 'with prefix_response_lines enabled' do
-            let(:prefix_response_lines) { true }
-            it { is_expected.to include('[httplog] <head>') }
-            it { is_expected.to include('[httplog] <title>Test Page</title>') }
+          unless adapter_class == OpenUriAdapter # Doesn't support response logging
+            context 'with prefix_response_lines enabled' do
+              let(:prefix_response_lines) { true }
 
-            context 'and blank response' do
-              let(:path) { '/empty.txt' }
-              it { is_expected.to include("[httplog] Response:\n") }
+              it { is_expected.to include('[httplog] <head>') }
+              it { is_expected.to include('[httplog] <title>Test Page</title>') }
+
+              context 'and blank response' do
+                let(:path) { '/empty.txt' }
+                it { is_expected.to include("[httplog] Response:\n") }
+              end
             end
           end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,11 +24,11 @@ Dir[File.dirname(__FILE__) + '/adapters/*.rb'].each { |f| require f }
 Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 # Start a local rack server to serve up test pages.
-@server_thread = Thread.new do
+Thread.new do
   Rack::Handler::Thin.run Httplog::Test::Server.new, Port: 9292
 end
 
-# wait for the server to be booted
+# Wait for the server to be booted.
 loop do
   TCPSocket.new('127.0.0.1', 9292).close
   break

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,15 @@ Dir['./spec/support/**/*.rb'].each { |f| require f }
 @server_thread = Thread.new do
   Rack::Handler::Thin.run Httplog::Test::Server.new, Port: 9292
 end
-sleep(3) # wait a moment for the server to be booted
+
+# wait for the server to be booted
+loop do
+  TCPSocket.new('127.0.0.1', 9292).close
+  break
+rescue Errno::ECONNREFUSED
+  sleep 0.1
+  retry
+end
 
 RSpec.configure do |config|
   Oj.default_options = {mode: :compat}


### PR DESCRIPTION
Without a fix, I get the following error in case of blank response: 

```
httplog-1.5.0/lib/httplog/http_log.rb:352:in `log_data_lines': undefined method `each_line' for nil:NilClass (NoMethodError)
```