### PR TITLE
Fix the missing Ethon log info

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thor (1.2.1)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.1)
@@ -159,6 +161,7 @@ DEPENDENCIES
   rspec (~> 3.7)
   simplecov (~> 0.15)
   thin (~> 1.7)
+  typhoeus (~> 1.4)
 
 BUNDLED WITH
    2.2.32

--- a/httplog.gemspec
+++ b/httplog.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'httparty', ['~> 0.16']
   gem.add_development_dependency 'httpclient', ['~> 2.8']
   gem.add_development_dependency 'rest-client', ['~> 2.0']
+  gem.add_development_dependency 'typhoeus', ['~> 1.4']
   gem.add_development_dependency 'listen', ['~> 3.0']
   gem.add_development_dependency 'patron', ['~> 0.12']
   gem.add_development_dependency 'rake', ['~> 13.0']

--- a/lib/httplog/adapters/ethon.rb
+++ b/lib/httplog/adapters/ethon.rb
@@ -22,9 +22,12 @@ if defined?(Ethon)
 
           bm = Benchmark.realtime { orig_perform }
 
+          url = @http_log[:url]
+          url = "#{url}?#{@http_log[:params]}" if @http_log[:params]
+
           HttpLog.call(
             method: @http_log[:method],
-            url: @http_log[:url],
+            url: url,
             request_body: @http_log[:body],
             request_headers: @http_log[:headers],
             response_code: @return_code,

--- a/lib/httplog/adapters/ethon.rb
+++ b/lib/httplog/adapters/ethon.rb
@@ -8,7 +8,7 @@ if defined?(Ethon)
       module Http
         alias orig_http_request http_request
         def http_request(url, action_name, options = {})
-          @http_log = options.merge(method: action_name) # remember this for compact logging
+          @http_log = options.merge(method: action_name, url: url) # remember this for compact logging
           orig_http_request(url, action_name, options)
         end
       end
@@ -31,7 +31,7 @@ if defined?(Ethon)
 
           HttpLog.call(
             method: @http_log[:method],
-            url: @url,
+            url: @http_log[:url],
             request_body: @http_log[:body],
             request_headers: @http_log[:headers],
             response_code: @return_code,

--- a/lib/httplog/adapters/ethon.rb
+++ b/lib/httplog/adapters/ethon.rb
@@ -18,16 +18,9 @@ if defined?(Ethon)
         def perform
           return orig_perform unless HttpLog.url_approved?(url)
 
+          httplog_add_callback
+
           bm = Benchmark.realtime { orig_perform }
-
-          # Not sure where the actual status code is stored - so let's
-          # extract it from the response header.
-          encoding = response_headers.scan(/Content-Encoding: (\S+)/).flatten.first
-          content_type = response_headers.scan(/Content-Type: (\S+(; charset=\S+)?)/).flatten.first
-
-          # Hard to believe that Ethon wouldn't parse out the headers into
-          # an array; probably overlooked it. Anyway, let's do it ourselves:
-          headers = response_headers.split(/\r?\n/).drop(1)
 
           HttpLog.call(
             method: @http_log[:method],
@@ -35,14 +28,36 @@ if defined?(Ethon)
             request_body: @http_log[:body],
             request_headers: @http_log[:headers],
             response_code: @return_code,
-            response_body: response_body,
-            response_headers: headers.map { |header| header.split(/:\s/) }.to_h,
+            response_body: @http_log[:response_body],
+            response_headers: @http_log[:response_headers].map { |header| header.split(/:\s/) }.to_h,
             benchmark: bm,
-            encoding: encoding,
-            content_type: content_type,
-            mask_body: HttpLog.masked_body_url?(url)
+            encoding: @http_log[:encoding],
+            content_type: @http_log[:content_type],
+            mask_body: HttpLog.masked_body_url?(@http_log[:url])
           )
           return_code
+        end
+
+        def httplog_add_callback
+          # Hack to perform this callback before the cleanup
+          @on_complete ||= []
+          @on_complete.unshift -> (*) do
+            # Not sure where the actual status code is stored - so let's
+            # extract it from the response header.
+            encoding = response_headers.scan(/Content-Encoding: (\S+)/).flatten.first
+            content_type = response_headers.scan(/Content-Type: (\S+(; charset=\S+)?)/).flatten.first
+
+            # Hard to believe that Ethon wouldn't parse out the headers into
+            # an array; probably overlooked it. Anyway, let's do it ourselves:
+            headers = response_headers.split(/\r?\n/).drop(1)
+
+            @http_log.merge!(
+              encoding: encoding,
+              content_type: content_type,
+              response_headers: headers,
+              response_body: response_body
+            )
+          end
         end
       end
     end

--- a/spec/adapters/typhoeus_adapter.rb
+++ b/spec/adapters/typhoeus_adapter.rb
@@ -3,19 +3,19 @@
 require 'excon'
 class TyphoeusAdapter < HTTPBaseAdapter
   def send_get_request
-    Typhoeus.get(parse_uri(true).to_s, headers: @headers)
+    Typhoeus.get(parse_uri(true).to_s, headers: @headers).body
   end
 
   def send_head_request
-    Typhoeus.head(parse_uri.to_s, headers: @headers)
+    Typhoeus.head(parse_uri.to_s, headers: @headers).body
   end
 
   def send_post_request
-    Typhoeus.post(parse_uri.to_s, body: @data, headers: @headers)
+    Typhoeus.post(parse_uri.to_s, body: @data, headers: @headers).body
   end
 
   def send_post_form_request
-    Typhoeus.post(parse_uri.to_s, body: @params, headers: @headers)
+    Typhoeus.post(parse_uri.to_s, body: @params, headers: @headers).body
   end
 
   def send_multipart_post_request

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -77,7 +77,8 @@ describe HttpLog do
     EthonAdapter,
     PatronAdapter,
     HTTPAdapter,
-    RestClientAdapter
+    RestClientAdapter,
+    TyphoeusAdapter
   ].freeze
 
   ADAPTERS.each do |adapter_class|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'rspec'
 require 'httpclient'
 require 'excon'
-# require 'typhoeus'
+require 'typhoeus'
 require 'ethon'
 require 'patron'
 require 'restclient'
@@ -25,7 +25,7 @@ Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 # Start a local rack server to serve up test pages.
 Thread.new do
-  Rack::Handler::Thin.run Httplog::Test::Server.new, Port: 9292
+  Rack::Handler::Thin.run Httplog::Test::Server.new, Host: '127.0.0.1', Port: 9292
 end
 
 # Wait for the server to be booted.


### PR DESCRIPTION
Currently using the `httplog` with `ethon`-based http lib we're getting a log with the missing URL in it.

```
 [httplog] Sending: GET
 [httplog] Header: accept: */*
 [httplog] Header: foo: bar
 [httplog] Connecting: localhost:9292
 [httplog] Status: 200
 [httplog] Benchmark: 0.001562 seconds
```

So we can memoize the URL in the `@http_log` variable and use it for logging.