### PR TITLE
add filtering of Addressable::URI

### DIFF
--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -319,6 +319,8 @@ module HttpLog
         string_classes << HTTP::URI if defined?(HTTP::URI)
         string_classes << URI::HTTP if defined?(URI::HTTP)
         string_classes << HTTP::FormData::Urlencoded if defined?(HTTP::FormData::Urlencoded)
+        string_classes << Addressable::URI if defined?(Addressable::URI)
+        string_classes << HTTPClient::Util::AddressableURI if defined?(HTTPClient::Util::AddressableURI)
         string_classes
       end
     end


### PR DESCRIPTION
Fix "FILTERING NOT APPLIED" message for Addressable::URI and HTTPClient::Util::AddressableURI