### PR TITLE
Chore/replace blacklist whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 
 ## 1.2.2 - 2019-03-15
 
-* [#70](https://github.com/trusche/httplog/pull/70) Fixed a bug where blacklisting caused requests to not be sent with HTTP adapter
+* [#70](https://github.com/trusche/httplog/pull/70) Fixed a bug where denylisting caused requests to not be sent with HTTP adapter
 
 ## 1.2.1 - 2019-01-28
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ HttpLog.configure do |config|
   config.color = false
 
   # Limit logging based on URL patterns
-  config.url_whitelist_pattern = nil
-  config.url_blacklist_pattern = nil
+  config.url_allowlist_pattern = nil
+  config.url_denylist_pattern = nil
 
   # Mask sensitive information in request and response JSON data.
   # Enable global JSON masking by setting the parameter to `/.*/`

--- a/lib/httplog/configuration.rb
+++ b/lib/httplog/configuration.rb
@@ -17,8 +17,8 @@ module HttpLog
                   :log_status,
                   :log_response,
                   :log_benchmark,
-                  :url_whitelist_pattern,
-                  :url_blacklist_pattern,
+                  :url_allowlist_pattern,
+                  :url_denylist_pattern,
                   :url_masked_body_pattern,
                   :color,
                   :prefix_data_lines,
@@ -43,8 +43,8 @@ module HttpLog
       @log_status              = true
       @log_response            = true
       @log_benchmark           = true
-      @url_whitelist_pattern   = nil
-      @url_blacklist_pattern   = nil
+      @url_allowlist_pattern   = nil
+      @url_denylist_pattern   = nil
       @url_masked_body_pattern = nil
       @color                   = false
       @prefix_data_lines       = false

--- a/lib/httplog/http_log.rb
+++ b/lib/httplog/http_log.rb
@@ -49,9 +49,9 @@ module HttpLog
     end
 
     def url_approved?(url)
-      return false if config.url_blacklist_pattern && url.to_s.match(config.url_blacklist_pattern)
+      return false if config.url_denylist_pattern && url.to_s.match(config.url_denylist_pattern)
 
-      !config.url_whitelist_pattern || url.to_s.match(config.url_whitelist_pattern)
+      !config.url_allowlist_pattern || url.to_s.match(config.url_allowlist_pattern)
     end
 
     def masked_body_url?(url)

--- a/spec/lib/http_log_spec.rb
+++ b/spec/lib/http_log_spec.rb
@@ -34,8 +34,8 @@ describe HttpLog do
   let(:json_log)                { HttpLog.configuration.json_log }
   let(:graylog_formatter)       { HttpLog.configuration.graylog_formatter }
   let(:compact_log)             { HttpLog.configuration.compact_log }
-  let(:url_blacklist_pattern)   { HttpLog.configuration.url_blacklist_pattern }
-  let(:url_whitelist_pattern)   { HttpLog.configuration.url_whitelist_pattern }
+  let(:url_denylist_pattern)   { HttpLog.configuration.url_denylist_pattern }
+  let(:url_allowlist_pattern)   { HttpLog.configuration.url_allowlist_pattern }
   let(:json_parser)             { HttpLog.configuration.json_parser }
   let(:filter_parameters)       { HttpLog.configuration.filter_parameters }
   let(:url_masked_body_pattern) { HttpLog.configuration.url_masked_body_pattern }
@@ -59,8 +59,8 @@ describe HttpLog do
       c.json_log              = json_log
       c.graylog_formatter     = graylog_formatter
       c.compact_log           = compact_log
-      c.url_blacklist_pattern = url_blacklist_pattern
-      c.url_whitelist_pattern = url_whitelist_pattern
+      c.url_denylist_pattern = url_denylist_pattern
+      c.url_allowlist_pattern = url_allowlist_pattern
       c.json_parser           = json_parser
       c.filter_parameters     = filter_parameters
       c.url_masked_body_pattern = url_masked_body_pattern
@@ -213,27 +213,27 @@ describe HttpLog do
           end
 
           context 'with blacklist hit' do
-            let(:url_blacklist_pattern) { /#{host}:#{port}/ }
+            let(:url_denylist_pattern) { /#{host}:#{port}/ }
             it_behaves_like 'logs nothing'
           end
 
           context 'with blacklist miss' do
-            let(:url_blacklist_pattern) { /example.com/ }
+            let(:url_denylist_pattern) { /example.com/ }
             it_behaves_like 'logs request', 'GET'
           end
 
           context 'with whitelist hit' do
-            let(:url_whitelist_pattern) { /#{host}:#{port}/ }
+            let(:url_allowlist_pattern) { /#{host}:#{port}/ }
             it_behaves_like 'logs request', 'GET'
 
             context 'and blacklist hit' do
-              let(:url_blacklist_pattern) { /#{host}:#{port}/ }
+              let(:url_denylist_pattern) { /#{host}:#{port}/ }
               it_behaves_like 'logs nothing'
             end
           end
 
           context 'with whitelist miss' do
-            let(:url_whitelist_pattern) { /example.com/ }
+            let(:url_allowlist_pattern) { /example.com/ }
             it_behaves_like 'logs nothing'
           end
 


### PR DESCRIPTION
## Adopt Inclusive Terminology: Replace Blacklist/Whitelist

This change replaces the terms blacklist and whitelist with denylist and allowlist respectively across the codebase.

### Justification:

The terms "blacklist" and "whitelist" can carry implicit racial connotations by associating the color black with rejection or negativity and white with acceptance or positivity.
As part of a broader industry-wide effort to create a more inclusive and welcoming environment in technology, we are adopting neutral and more descriptive alternatives. The terms denylist and allowlist are not only free of potentially biased connotations but are also more explicit about their technical function, improving clarity in the code.
This update aligns our project with the best practices being adopted by many other open-source projects and technology companies.