### PR TITLE
docs: recommend using an initializer for Rails configuration with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,17 @@ HttpLog.configure do |config|
 end
 ```
 
-If you want to use this in a Rails app, I'd suggest configuring this specifically for each environment. A global initializer is not a good idea since `HttpLog` will be undefined in production. Because you're **not using this in production**, right? :)
+If you want to use this in a Rails app, it is recommended to configure `HttpLog` in an initializer, as suggested by the official Rails documentation. This approach ensures that your configuration is loaded properly and only in the desired environments.
+
+For example, you can create a file at `config/initializers/httplog.rb` with the following content:
 
 ```ruby
-# config/environments/development.rb
+# config/initializers/httplog.rb
 
-HttpLog.configure do |config|
-  config.logger = Rails.logger
+if Rails.env.development?
+  HttpLog.configure do |config|
+    config.logger = Rails.logger
+  end
 end
 ```
 


### PR DESCRIPTION
### Why update the Rails usage example in the README?

In Rails 6 and later, the application’s environment configuration files (such as those in `config/environments/`) are loaded before some core components, including `Rails.logger`, are fully initialized. This means that if you try to configure `HttpLog` and set `config.logger = Rails.logger` directly in an environment file, `Rails.logger` may not yet be available, which can cause errors or unexpected behavior when using this gem.

To avoid this issue and follow best practices recommended by the Rails documentation, it is preferable to place the `HttpLog` configuration inside an initializer (e.g., `config/initializers/httplog.rb`). By doing so, you ensure that all necessary Rails components, including the logger, are properly loaded before the configuration is applied.

This PR updates the README to recommend using an initializer for `HttpLog` configuration, and provides an example that safely applies the configuration only in the development environment.