### PR TITLE
Fixes bug parsing bare headers with ethon

### DIFF
--- a/lib/httplog/adapters/ethon.rb
+++ b/lib/httplog/adapters/ethon.rb
@@ -32,7 +32,7 @@ if defined?(Ethon)
             request_headers: @http_log[:headers],
             response_code: @return_code,
             response_body: @http_log[:response_body],
-            response_headers: @http_log[:response_headers].map { |header| header.split(/:\s/) }.to_h,
+            response_headers: @http_log[:response_headers].map { |header| parts = header.split(/:\s*/, 2); [parts[0], parts[1] || "true"] }.to_h,
             benchmark: bm,
             encoding: @http_log[:encoding],
             content_type: @http_log[:content_type],


### PR DESCRIPTION
There's a bug in ethon adapter header parsing, where if a bare header is received (eg, a header without a value), `HttpLog` raises an exception. Here's an example output from the line (before the `.to_h`) for a request we were testing recently:
```
> @http_log[:response_headers].map { |header| parts = header.split(/:\s*/) }

[["Date", "Mon, 04 Aug 2025 22:19:18 GMT"],
 ["Content-Type", "application/json"],
 ["Transfer-Encoding", "chunked"],
 ["Connection", "keep-alive"],
 ["Access-Control-Allow-Methods", "GET, OPTIONS"],
 ["Access-Control-Allow-Origin", "*"],
 ["Access-Control-Max-Age", "86400"],
 ["Etag", "W/\"82d52c4d57da427f64b256bd46e452bddc7d2496\""],
 ["X-Embedly-From-Cache"],
 ["X-Embedly-Host", "unearth-b-01"],
 ["X-Embedly-Process-Time", "492"],
 ["cf-cache-status", "DYNAMIC"],
 ["vary", "accept-encoding"],
 ["Server", "cloudflare"],
 ["CF-RAY", "96a16f7c8baef0e4-LAX"]]
```

Notice how `X-Embedly-From-Cache` has no corresponding value. This is a valid header according to the spec, but the ethon adapter fails to parse it properly.

This PR fixes the bug. I had trouble trying to figure out a decent spec so I didn't add a failing test case. If you have any suggestions for how to write that failing test, I'd love to add it.